### PR TITLE
Feat: Adjust tree proportions and leaf size

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -599,25 +599,25 @@
             'media': {
                 physics: {
                     trunk: { width: cobWidth, height: 2.0, depth: cobWidth, yOffset: -0.8 },
-                    leaves: { width: cobWidth * 2, height: cobWidth * 2, depth: cobWidth * 2, yOffset: 0.8 }
+                    leaves: { width: cobWidth * 4, height: cobWidth * 4, depth: cobWidth * 4, yOffset: 0.8 }
                 },
                 visual: {
                     trunk: { radius: cobWidth / 2, height: 2.0, yOffsetInGroup: (2.0 / 2) - (3.6 / 2) },
-                    leaves: { radius: cobWidth, yOffsetInGroup: (2.0 + 0.8) - (3.6 / 2) }
+                    leaves: { radius: cobWidth * 2, yOffsetInGroup: (2.0 + 0.8) - (3.6 / 2) }
                 },
-                overallPhysicsHeight: 3.6,
+                overallPhysicsHeight: 3.6, // Will be recalculated by randomizeTreeDimensions
                 growthTime: 10
             },
             'arvore_adulta': {
                 physics: {
-                    trunk: { width: cobWidth * 1.5, height: 5.0, depth: cobWidth * 1.5, yOffset: -2.0 },
-                    leaves: { width: cobWidth * 4, height: cobWidth * 4, depth: cobWidth * 4, yOffset: 2.0 }
+                    trunk: { width: cobWidth, height: 5.0, depth: cobWidth, yOffset: -2.0 },
+                    leaves: { width: cobWidth * 8, height: cobWidth * 8, depth: cobWidth * 8, yOffset: 2.0 }
                 },
                 visual: {
-                    trunk: { radius: cobWidth * 0.75, height: 5.0, yOffsetInGroup: (5.0 / 2) - (9.0 / 2) },
-                    leaves: { radius: cobWidth * 2, yOffsetInGroup: (5.0 + 2.0) - (9.0 / 2) }
+                    trunk: { radius: cobWidth / 2, height: 5.0, yOffsetInGroup: (5.0 / 2) - (9.0 / 2) },
+                    leaves: { radius: cobWidth * 4, yOffsetInGroup: (5.0 + 2.0) - (9.0 / 2) }
                 },
-                overallPhysicsHeight: 9.0,
+                overallPhysicsHeight: 9.0, // Will be recalculated by randomizeTreeDimensions
                 growthTime: Infinity // Fully grown
             }
         };


### PR DESCRIPTION
This commit implements two user-requested changes to the tree growth system:
1.  The trunk width for the 'media' and 'arvore_adulta' growth stages has been standardized to match the width of the placeable trunk item, ensuring visual consistency.
2.  The leaf size for the 'media' and 'arvore_adulta' stages has been significantly increased to make the trees appear fuller and more substantial as they grow.

The `treeStages` object in `index.htm` has been updated with these new dimensions. The existing `randomizeTreeDimensions` function correctly handles these new base values to generate the final tree appearance.