### PR TITLE
feat: Cria lago semicircular procedural com natação

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -376,6 +376,8 @@
         let playerBody;
         let streetBody; // Corpo de física para o terreno (agora verde)
         let streetMeshes = []; // Array para armazenar múltiplas malhas visuais do terreno
+        let waterMeshes = []; // NOVO: Array para as malhas da água
+        let waterLevel; // NOVO: Nível da água para a física de natação
 
         let roadBody; // Corpo de física para o estrada (agora cinza)
         let roadMeshes = []; // Array para armazenar múltiplas malhas visuais da estrada
@@ -1203,9 +1205,19 @@
             placedConstructionBodies.push(blockBody);
             console.log("Bloco colocado. Corpos de construção colocados:", placedConstructionBodies); // Log para depuração
 
-            mesh.userData.physicsBody = blockBody; // Vincula a malha visual ao corpo de física
-            scene.add(mesh);
-            placedConstructionMeshesArrays.push([{ mesh: mesh, offsetX: 0, offsetZ: 0 }]); // Simplified for single mesh/group per body
+            blockBody.userData.physicsBody = blockBody; // Vincula o corpo de física a si mesmo para referência
+
+            const blockMeshes = [];
+            for (let i = -Math.floor(numTiles / 2); i <= Math.floor(numTiles / 2); i++) {
+                for (let j = -Math.floor(numTiles / 2); j <= Math.floor(numTiles / 2); j++) {
+                    // Clona a malha ou grupo para cada tile
+                    const meshInstance = mesh.clone(true); // O 'true' clona recursivamente (importante para grupos de árvores)
+                    meshInstance.userData.physicsBody = blockBody; // Vincula a instância da malha ao corpo de física
+                    scene.add(meshInstance);
+                    blockMeshes.push({ mesh: meshInstance, offsetX: i * worldSize, offsetZ: j * worldSize });
+                }
+            }
+            placedConstructionMeshesArrays.push(blockMeshes); // Adiciona o array de malhas
         }
 
         // Function to create a smoke effect at a given position
@@ -1381,34 +1393,66 @@
             scene.add(directionalLight);
             scene.add(directionalLight.target); // Adiciona o alvo à cena para atualizações de posição
 
-            // Cria o Terreno (agora composto de blocos de cob)
-            const streetShape = new CANNON.Box(new CANNON.Vec3(worldSize / 2, streetHeight / 2, worldSize / 2));
-            streetBody = new CANNON.Body({ mass: 0, shape: streetShape, material: streetMaterial });
-            streetBody.position.set(0, streetHeight / 2, 0); // Posição na metade de sua altura para ter o topo em y=0
-            world.addBody(streetBody);
+            // A criação do terreno plano (streetBody) foi removida para dar lugar à geração procedural.
 
-            const streetGeometry = new THREE.BoxGeometry(worldSize, streetHeight, worldSize);
-            // Carrega a textura de terra para o terreno
-            const groundTexture = textureLoader.load('https://dl.dropbox.com/scl/fi/m3hxsvvmn1fqh9a9y005a/Textura-de-terra-qualidade-inferior.png?rlkey=drythuhadiioy1975o6svmymx&st=6iqo4hws&dl=0', (texture) => {
-                // Configura a repetição da textura
-                texture.wrapS = THREE.RepeatWrapping;
-                texture.wrapT = THREE.RepeatWrapping;
-                // Ajusta a repetição da textura.
-                texture.repeat.set(worldSize / cobWidth, worldSize / cobDepth);
-            });
-            const streetMeshMaterial = new THREE.MeshStandardMaterial({ map: groundTexture });
-            for (let i = -Math.floor(numTiles / 2); i <= Math.floor(numTiles / 2); i++) {
-                for (let j = -Math.floor(numTiles / 2); j <= Math.floor(numTiles / 2); j++) {
-                    const mesh = new THREE.Mesh(streetGeometry, streetMeshMaterial);
-                    mesh.receiveShadow = true;
-                    mesh.userData.physicsBody = streetBody; // ASSOCIA O CORPO DE FÍSICA À MALHA VISUAL
-                    scene.add(mesh);
-                    // Armazena a malha e seu offset ideal da origem (0,0,0)
-                    streetMeshes.push({ mesh: mesh, offsetX: i * worldSize, offsetZ: j * worldSize });
+            // --- GERAÇÃO PROCEDURAL DA ILHA E DO LAGO ---
+            const islandRadius = worldSize / 2.5; // Raio da ilha principal
+            const lakeRadius = worldSize / 4; // Raio da depressão do lago
+            const lakeDepth = 2; // Profundidade do lago em relação ao nível do solo
+
+            // Itera sobre uma grade para colocar os blocos de terra
+            for (let i = -Math.floor(worldSize / 2 / cobSize); i <= Math.floor(worldSize / 2 / cobSize); i++) {
+                for (let j = -Math.floor(worldSize / 2 / cobSize); j <= Math.floor(worldSize / 2 / cobSize); j++) {
+                    const x = i * cobSize;
+                    const z = j * cobSize;
+                    const distFromCenter = Math.sqrt(x * x + z * z);
+
+                    // Só cria blocos dentro do raio da ilha
+                    if (distFromCenter < islandRadius) {
+                        let y = streetHeight; // Altura padrão do solo
+
+                        // Verifica se o bloco está na área do lago (semicírculo na parte +z)
+                        if (z > 0 && distFromCenter < lakeRadius) {
+                            y -= lakeDepth; // Afunda o bloco para criar o leito do lago
+                        }
+
+                        // Cria a posição e o quaternion para o bloco
+                        const position = new CANNON.Vec3(x, y - cobHeight / 2, z);
+                        const quaternion = new CANNON.Quaternion(); // Rotação padrão (nenhuma)
+
+                        // Usa a função existente para criar blocos estáticos de 'cob'
+                        // Isso garante que eles tenham a física e a renderização corretas (incluindo a duplicação 3x3)
+                        createPlaceableBlock(position, quaternion, 'cob');
+                    }
                 }
             }
 
-            // A rua foi removida, então o código relacionado a ela foi excluído.
+            // --- CRIAÇÃO DA ÁGUA DO LAGO ---
+            waterLevel = streetHeight - 0.1; // Um pouco abaixo do nível do solo
+            const lakeRadius = worldSize / 4; // Raio do lago (deve corresponder ao da geração da ilha)
+            const waterGeometry = new THREE.CircleGeometry(lakeRadius, 32, 0, Math.PI); // Semicírculo
+            const waterMaterial = new THREE.MeshStandardMaterial({
+                color: 0x006994, // Azul da água
+                transparent: true,
+                opacity: 0.7,
+                roughness: 0.1,
+                metalness: 0.0
+            });
+
+            // Gira a geometria para ficar plana no eixo XZ e a posiciona no lado +Z
+            waterGeometry.rotateX(-Math.PI / 2);
+            waterGeometry.translate(0, 0, lakeRadius / 2.15); // Ajuste fino para alinhar com a depressão
+
+
+            for (let i = -Math.floor(numTiles / 2); i <= Math.floor(numTiles / 2); i++) {
+                for (let j = -Math.floor(numTiles / 2); j <= Math.floor(numTiles / 2); j++) {
+                    const waterMesh = new THREE.Mesh(waterGeometry, waterMaterial);
+                    waterMesh.position.y = waterLevel;
+                    waterMesh.receiveShadow = true; // Permite que a água receba sombras
+                    scene.add(waterMesh);
+                    waterMeshes.push({ mesh: waterMesh, offsetX: i * worldSize, offsetZ: j * worldSize });
+                }
+            }
 
             // Cria o Corpo de Física do Jogador (esfera)
             originalPlayerShape = new CANNON.Sphere(playerRadius); // Esfera com raio baseado na altura
@@ -1433,7 +1477,7 @@
             playerBody.addEventListener('collide', (event) => {
                 // canJump é verdadeiro APENAS se o corpo colidido NÃO for o objeto que está sendo segurado
                 // A lista de corpos "chão" agora inclui apenas superfícies que podem ser pisadas
-                const allGroundBodies = [streetBody, ...collectibleBoxes.map(b => b.body), ...placedConstructionBodies];
+                const allGroundBodies = [...collectibleBoxes.map(b => b.body), ...placedConstructionBodies];
                 if (event.body !== pickedObjectBody && allGroundBodies.includes(event.body)) {
                     canJump = true;
                 }
@@ -2221,6 +2265,21 @@
             // Atualiza o mundo da física
             world.step(1 / 60);
 
+            // --- LÓGICA DE NATAÇÃO ---
+            if (playerBody.position.y < waterLevel) {
+                // Aplica uma força de flutuação que é um pouco menor que a gravidade,
+                // permitindo que o jogador afunde lentamente.
+                const buoyancyForce = new CANNON.Vec3(0, playerBody.mass * (Math.abs(world.gravity.y) * 0.95), 0);
+                playerBody.applyForce(buoyancyForce, playerBody.position);
+
+                // Aumenta o amortecimento para simular a resistência da água e tornar o movimento mais lento.
+                playerBody.linearDamping = 0.98;
+            } else {
+                // Restaura o amortecimento linear padrão quando o jogador está fora da água.
+                playerBody.linearDamping = 0.9;
+            }
+
+
             // Lógica para os cubos e blocos: sempre dinâmicos e com massa original, a menos que sejam segurados
             // Apenas os cubos são pickable agora
             const allPickableBodies = collectibleBoxes.map(b => b.body);
@@ -2265,14 +2324,14 @@
             const visualOffsetX = Math.round(playerX / worldSize) * worldSize;
             const visualOffsetZ = Math.round(playerZ / worldSize) * worldSize;
 
-            // Atualiza as posições das malhas do terreno com base na posição envolvida do jogador
-            streetMeshes.forEach(tile => {
+            // A atualização das malhas do terreno (streetMeshes) foi removida,
+            // pois o terreno agora é composto de blocos individuais atualizados abaixo.
+
+            // NOVO: Atualiza as posições das malhas da água
+            waterMeshes.forEach(tile => {
                 tile.mesh.position.x = tile.offsetX - visualOffsetX;
                 tile.mesh.position.z = tile.offsetZ - visualOffsetZ;
-                tile.mesh.position.y = streetHeight / 2;
-                tile.mesh.quaternion.copy(streetBody.quaternion);
             });
-            // A rua foi removida, então não há necessidade de atualizar roadMeshes.
 
             // Atualiza as posições de todas as malhas visuais dos cubos/caixas
             collectibleBoxes.forEach(box => {
@@ -2281,13 +2340,10 @@
 
             // Atualiza as posições de todas as malhas visuais dos blocos colocados
             placedConstructionBodies.forEach((body, index) => {
-                // Cada corpo de bloco colocado agora tem apenas uma malha visual.
-                // Acessamos diretamente a malha no primeiro (e único) elemento do array de malhas para aquele corpo.
-                const meshToUpdate = placedConstructionMeshesArrays[index][0].mesh;
-                meshToUpdate.position.x = body.position.x + placedConstructionMeshesArrays[index][0].offsetX - visualOffsetX;
-                meshToUpdate.position.y = body.position.y;
-                meshToUpdate.position.z = body.position.z + placedConstructionMeshesArrays[index][0].offsetZ - visualOffsetZ;
-                meshToUpdate.quaternion.copy(body.quaternion); // Mantém a rotação
+                const meshesArray = placedConstructionMeshesArrays[index];
+                if (meshesArray) { // Garante que o array de malhas exista
+                    updateObjectVisuals(body, meshesArray, visualOffsetX, visualOffsetZ);
+                }
             });
 
 
@@ -2520,7 +2576,7 @@
 
 
                     // Lista de todos os corpos que podem ser base para colocação
-                    const allPlaceableSurfaces = [streetBody, ...placedConstructionBodies];
+                    const allPlaceableSurfaces = [...placedConstructionBodies];
 
                     for (let i = 0; i < intersects.length; i++) {
                         const intersectedObject = intersects[i].object;
@@ -2810,7 +2866,7 @@
             // Verifica colisão com terreno (rua), estrada, cubos e blocos
             world.raycastAny(rayOriginLow, rayTargetLow, {}, rayResultStep);
             // A lista de corpos "chão" para subida de degraus
-            const stepClimbGroundBodies = [streetBody, ...collectibleBoxes.map(b => b.body), ...placedConstructionBodies];
+            const stepClimbGroundBodies = [...collectibleBoxes.map(b => b.body), ...placedConstructionBodies];
             if (rayResultStep.hasHit && stepClimbGroundBodies.includes(rayResultStep.body)) {
                 hitLow = true;
             }


### PR DESCRIPTION
Remove o terreno plano (`streetBody`) e implementa a geração procedural de uma ilha circular composta por blocos individuais.

Dentro da ilha, uma depressão semicircular é criada para formar o leito de um lago. Uma malha de água visual e transparente é adicionada sobre essa área.

Implementa a física de natação: quando o jogador está abaixo do nível da água, uma força de flutuação e um amortecimento linear aumentado são aplicados para simular a resistência da água e permitir que o jogador afunde lentamente.

Refatora a renderização de todos os blocos colocados para usar o sistema de grade 3x3, garantindo que eles se repitam corretamente no mundo contínuo. Atualiza todas as lógicas de colisão para usar os novos blocos de terreno.