### PR TITLE
fix: Correct shader logic to prevent object invisibility

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1250,15 +1250,17 @@
                     varying vec3 vWorldPosition;
                 ` + shader.vertexShader;
 
-                // Modifica o final do vertex shader para calcular o deslocamento
+                // Injeta o código para modificar a posição do vértice
                 shader.vertexShader = shader.vertexShader.replace(
-                    '#include <worldpos_vertex>',
+                    '#include <project_vertex>',
                     `
-                    #include <worldpos_vertex>
+                    vec4 worldPosition = modelMatrix * vec4( transformed, 1.0 );
+
                     vWorldPosition = worldPosition.xyz;
                     float dist = length(worldPosition.xz - cameraPos.xz);
                     worldPosition.y -= dist * dist * 0.00003;
-                    gl_Position = projectionMatrix * modelViewMatrix * vec4(worldPosition, 1.0);
+
+                    gl_Position = projectionMatrix * viewMatrix * worldPosition;
                     `
                 );
             };


### PR DESCRIPTION
This commit fixes a bug in the vertex shader that caused objects with the horizon effect to become invisible.

The previous implementation incorrectly manipulated the vertex positions by replacing the `#include <worldpos_vertex>` chunk and using `modelViewMatrix`. This resulted in an incorrect final `gl_Position`.

The corrected implementation now injects the custom GLSL code at the `#include <project_vertex>` point in the shader. It correctly calculates the `worldPosition` and then applies the curvature effect. The final vertex position is now correctly calculated using `projectionMatrix * viewMatrix * worldPosition`, ensuring the objects are rendered in the correct location and the horizon effect is properly applied.