### PR TITLE
Feat: Apply horizon curve effect to boxes

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1475,17 +1475,18 @@
             // --- Configuração dos Cubos Interativos ---
             const cubeSize = 1;
             // Carrega a textura para os cubos e cria o material global
-            const cubeTexture = textureLoader.load(cubeTextureURL);
-            cubeTexture.wrapS = THREE.RepeatWrapping;
-            cubeTexture.wrapT = THREE.RepeatWrapping;
-            cubeTexture.repeat.set(1, 1);
-            cubeMaterialMesh = new THREE.MeshStandardMaterial({ map: cubeTexture });
-            setupPlanetShader(cubeMaterialMesh); // Aplica o efeito de planeta
+            textureLoader.load(cubeTextureURL, (texture) => {
+                texture.wrapS = THREE.RepeatWrapping;
+                texture.wrapT = THREE.RepeatWrapping;
+                texture.repeat.set(1, 1);
+                cubeMaterialMesh = new THREE.MeshStandardMaterial({ map: texture });
+                setupPlanetShader(cubeMaterialMesh); // Aplica o efeito de planeta
 
-            // Cria as caixas iniciais usando a função createBox
-            createBox(new THREE.Vector3(0, cubeSize / 2 + streetHeight, -10));
-            createBox(new THREE.Vector3(5, cubeSize / 2 + streetHeight, -10));
-            createBox(new THREE.Vector3(-5, cubeSize / 2 + streetHeight, -10));
+                // Cria as caixas iniciais usando a função createBox
+                createBox(new THREE.Vector3(0, cubeSize / 2 + streetHeight, -10));
+                createBox(new THREE.Vector3(5, cubeSize / 2 + streetHeight, -10));
+                createBox(new THREE.Vector3(-5, cubeSize / 2 + streetHeight, -10));
+            });
 
             // Cria o ghost block (transparente)
             const ghostBlockMaterial = new THREE.MeshBasicMaterial({


### PR DESCRIPTION
Refactors the material loading for the interactive boxes (`cubeMaterialMesh`) to ensure the custom "small planet" shader is applied correctly.

The `cubeMaterialMesh` and the initial `createBox` calls are now placed inside the `textureLoader.load` callback. This guarantees that the texture is fully loaded and processed before the material is compiled and used to create the boxes, preventing a race condition where the shader might be inapplied to a material without its texture.

This change ensures that the boxes now correctly curve and disappear over the horizon, consistent with other objects in the world.