### PR TITLE
Feat: Implement render distance culling

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -386,6 +386,8 @@
         // Variáveis para blocos de construção colocáveis pelo jogador (tijolos e pisos)
         let placedConstructionBodies = []; // Corpos de blocos colocados pelo jogador
         let placedConstructionMeshesArrays = []; // Malhas de blocos colocados pelo jogador
+        let visualOffsetX = 0;
+        let visualOffsetZ = 0;
 
         // Objeto para rastrear as teclas pressionadas
         let keysPressed = {};
@@ -408,6 +410,7 @@
         let targetDestroyTime = 0; // Tempo necessário para destruir o objeto (em segundos)
         let destroyTargetBody = null; // Corpo que está sendo destruído
         let destroyTargetMesh = null; // Malha visual do corpo
+        let destroyTargetPatchObject = null;
 
         // NOVO: Variáveis para a lógica de clique vs. segurar
         let mouseDownTime = 0;
@@ -436,6 +439,7 @@
 
         // Define as dimensões do mundo para X e Z (para efeito de envolvimento)
         const worldSize = 400;
+        const renderDistance = 100; // Distância de renderização para objetos
         // NOVO: A altura do terreno e a altura dos blocos de cob são agora as mesmas.
         const cobSize = 0.4;
         const streetHeight = cobSize;
@@ -1428,6 +1432,7 @@
             // Posição inicial: centro da esfera em playerRadius + streetHeight
             playerBody.position.set(0, playerRadius + streetHeight, 0); // Posição inicial ajustada do jogador
             world.addBody(playerBody);
+            window.playerBody = playerBody; // Exposto globalmente para o script de verificação
 
             // Reintroduz o listener de colisão para canJump, mas com uma verificação adicional
             playerBody.addEventListener('collide', (event) => {
@@ -1816,10 +1821,18 @@
                 for (let i = 0; i < intersects.length; i++) {
                     if (intersects[i].distance > destroyDistance) continue;
                     let intersectedObject = intersects[i].object;
-                    if (intersectedObject.userData && intersectedObject.userData.isDestructible && intersectedObject.userData.type === 'patch') {
-                        target = { body: null, mesh: intersectedObject };
+
+                    // Lógica de destruição de patch atualizada
+                    if (intersectedObject.userData.patchObject) {
+                        const patchObject = intersectedObject.userData.patchObject;
+                        target = {
+                            body: null, // Patches não têm corpo de física
+                            mesh: intersectedObject, // A malha específica que foi atingida
+                            patchObject: patchObject // O objeto principal do patch
+                        };
                         break;
                     }
+
                     let mainObject = null, intersectedBody = null;
                     let currentObject = intersectedObject;
                     while (currentObject) {
@@ -1840,9 +1853,21 @@
                     destroyProgress = 0;
                     destroyTargetBody = target.body;
                     destroyTargetMesh = target.mesh;
-                    const targetUserData = target.body ? target.body.userData : target.mesh.userData;
-                    targetDestroyTime = targetUserData.durability || 1.0;
-                    progressContainer.style.display = 'block';
+                    destroyTargetPatchObject = target.patchObject || null; // Armazena o objeto do patch se existir
+
+                    let targetUserData;
+                    if (destroyTargetPatchObject) {
+                        targetUserData = destroyTargetPatchObject.userData;
+                    } else if (destroyTargetBody) {
+                        targetUserData = destroyTargetBody.userData;
+                    }
+
+                    if (targetUserData) {
+                        targetDestroyTime = targetUserData.durability || 1.0;
+                        progressContainer.style.display = 'block';
+                    } else {
+                        isDestroying = false; // Não encontrou dados do usuário, cancela a destruição
+                    }
                 }
             }
 
@@ -1852,6 +1877,7 @@
                 progressContainer.style.display = 'none';
                 destroyTargetBody = null;
                 destroyTargetMesh = null;
+                destroyTargetPatchObject = null;
             }
 
             function collectObject() {
@@ -1969,15 +1995,32 @@
                     const intersect = intersects[0];
                     const hitPoint = intersect.point;
                     const patchSize = cobSize;
-                    const snappedX = Math.floor(hitPoint.x / patchSize) * patchSize + patchSize / 2;
-                    const snappedZ = Math.floor(hitPoint.z / patchSize) * patchSize + patchSize / 2;
+
+                    // Calcula a posição "desenrolada" (absoluta) do patch
+                    const unwrappedHitPointX = hitPoint.x + visualOffsetX;
+                    const unwrappedHitPointZ = hitPoint.z + visualOffsetZ;
+                    const unwrappedSnappedX = Math.floor(unwrappedHitPointX / patchSize) * patchSize + patchSize / 2;
+                    const unwrappedSnappedZ = Math.floor(unwrappedHitPointZ / patchSize) * patchSize + patchSize / 2;
+
                     const patchGeometry = new THREE.BoxGeometry(patchSize, 0.01, patchSize);
-                    const patchMesh = new THREE.Mesh(patchGeometry, stoneMaterial);
-                    patchMesh.position.set(snappedX, streetHeight + 0.005, snappedZ);
-                    patchMesh.receiveShadow = true;
-                    patchMesh.userData = { isDestructible: true, durability: 0.5, type: 'patch' };
-                    scene.add(patchMesh);
-                    texturePatches.push(patchMesh);
+                    const patchMeshes = [];
+                    const patchObject = {
+                        position: new CANNON.Vec3(unwrappedSnappedX, streetHeight + 0.005, unwrappedSnappedZ),
+                        meshes: patchMeshes,
+                        userData: { isDestructible: true, durability: 0.5, type: 'patch' }
+                    };
+
+                    for (let i = -Math.floor(numTiles / 2); i <= Math.floor(numTiles / 2); i++) {
+                        for (let j = -Math.floor(numTiles / 2); j <= Math.floor(numTiles / 2); j++) {
+                            const mesh = new THREE.Mesh(patchGeometry, stoneMaterial);
+                            mesh.receiveShadow = true;
+                            // A malha principal (0,0) obtém os dados do usuário para detecção de destruição
+                            mesh.userData.patchObject = patchObject; // Referência de volta ao objeto principal
+                            scene.add(mesh);
+                            patchMeshes.push({ mesh: mesh, offsetX: i * worldSize, offsetZ: j * worldSize });
+                        }
+                    }
+                    texturePatches.push(patchObject);
                 }
             }
 
@@ -2116,99 +2159,105 @@
             }
 
             // Lógica de destruição progressiva
-            if (isDestroying && destroyTargetMesh) { // Check destroyTargetMesh instead of Body
-                // --- NOVO: Verificação se a mira ainda está no objeto ---
+            if (isDestroying && (destroyTargetMesh || destroyTargetPatchObject)) {
+                // --- Verificação de mira atualizada ---
                 raycaster.setFromCamera(new THREE.Vector2(0, 0), camera);
                 const intersects = raycaster.intersectObjects(scene.children, true);
 
-                let currentTargetMesh = null;
+                let stillOnTarget = false;
                 if (intersects.length > 0 && intersects[0].distance <= destroyDistance) {
-                    currentTargetMesh = intersects[0].object;
-                     // Traverse up if it's part of a group that is the target
-                    let parent = currentTargetMesh.parent;
-                    while(parent && parent !== scene) {
-                        if (parent === destroyTargetMesh) {
-                            currentTargetMesh = parent;
-                            break;
+                    let intersectedObject = intersects[0].object;
+
+                    if (destroyTargetPatchObject) {
+                        // Se estivermos destruindo um patch, verifica se a malha atingida pertence ao patch
+                        if (intersectedObject.userData.patchObject === destroyTargetPatchObject) {
+                            stillOnTarget = true;
                         }
-                        parent = parent.parent;
+                    } else if (destroyTargetMesh) {
+                        // Se estivermos destruindo um bloco, faz a verificação normal
+                        let currentObject = intersectedObject;
+                        while (currentObject) {
+                            if (currentObject === destroyTargetMesh) {
+                                stillOnTarget = true;
+                                break;
+                            }
+                            currentObject = currentObject.parent;
+                        }
                     }
                 }
 
-                // Se o objeto na mira não for mais o objeto que está sendo destruído, reseta.
-                if (currentTargetMesh !== destroyTargetMesh) {
-                    isDestroying = false;
-                    destroyProgress = 0;
-                    progressContainer.style.display = 'none';
-                    destroyTargetBody = null;
-                    destroyTargetMesh = null;
+                // Se não estiver mais na mira, reseta
+                if (!stillOnTarget) {
+                    stopDestruction();
                 } else {
-                // Se a mira ainda estiver no objeto, continua o progresso
-                destroyProgress += 1 / 60; // Aumenta o progresso a cada frame (assumindo 60 FPS)
-                if (destroyProgress >= targetDestroyTime) {
-                    // Objeto destruído!
-                    const position = destroyTargetMesh.position.clone();
+                    // Se estiver na mira, continua o progresso
+                    destroyProgress += 1 / 60;
+                    if (destroyProgress >= targetDestroyTime) {
+                        // Objeto destruído!
+                        let position;
 
-                    // Handle patch destruction
-                    if (destroyTargetMesh.userData.type === 'patch') {
-                       const patchIndex = texturePatches.indexOf(destroyTargetMesh);
-                       if (patchIndex > -1) {
-                           texturePatches.splice(patchIndex, 1);
-                       }
-                       scene.remove(destroyTargetMesh);
-                       if (destroyTargetMesh.geometry) destroyTargetMesh.geometry.dispose();
-                       // Give back a stone item
-                       addItemToInventory(backpackItems, { name: stoneItemName, quantity: 1 });
-                       updateBackpackDisplay();
+                        // Handle patch destruction
+                        if (destroyTargetPatchObject) {
+                            position = destroyTargetPatchObject.position.clone();
+                            const patchIndex = texturePatches.indexOf(destroyTargetPatchObject);
+                            if (patchIndex > -1) {
+                                texturePatches.splice(patchIndex, 1);
+                            }
+                            destroyTargetPatchObject.meshes.forEach(m => {
+                                scene.remove(m.mesh);
+                                if (m.mesh.geometry) m.mesh.geometry.dispose();
+                            });
+                            addItemToInventory(backpackItems, { name: stoneItemName, quantity: 1 });
+                            updateBackpackDisplay();
+                        }
+                        // Handle regular block destruction
+                        else if (destroyTargetBody) {
+                            position = destroyTargetMesh.position.clone();
+                            const bodyIndex = placedConstructionBodies.indexOf(destroyTargetBody);
+                            if (bodyIndex !== -1) {
+                               // Adiciona a lógica de recompensa de troncos com base no estágio da árvore
+                               if (destroyTargetBody.userData.growthStage === 'media') {
+                                   addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 1 });
+                               } else if (destroyTargetBody.userData.growthStage === 'arvore_adulta') {
+                                   addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 3 });
+                               }
+                               // Adiciona tábuas de madeira ao inventário se o objeto destruído for um tronco ou tábua
+                               else if (destroyTargetBody.userData.type === 'tronco_arvore' || destroyTargetBody.userData.type === 'tábuas') {
+                                   addItemToInventory(backpackItems, { name: woodenPlankItemName, quantity: 2 });
+                               }
+                               // Adiciona o item original ao inventário ao destruir
+                               if (destroyTargetBody.userData.type === 'cob' || destroyTargetBody.userData.type === 'piso') {
+                                   addItemToInventory(backpackItems, { name: destroyTargetBody.userData.type, quantity: 1 });
+                               }
+                               updateBackpackDisplay();
+
+                               world.removeBody(destroyTargetBody);
+                               placedConstructionBodies.splice(bodyIndex, 1);
+                               scene.remove(destroyTargetMesh);
+                               if (destroyTargetMesh.isGroup) {
+                                   destroyTargetMesh.children.forEach(child => {
+                                       if (child.geometry) child.geometry.dispose();
+                                   });
+                               } else if (destroyTargetMesh.geometry) {
+                                   destroyTargetMesh.geometry.dispose();
+                               }
+                               placedConstructionMeshesArrays.splice(bodyIndex, 1);
+                            }
+                        }
+
+                        if (position) createSmokeEffect(position);
+                        stopDestruction(); // Reseta tudo
+
+                    } else {
+                        // Atualiza a barra de progresso
+                        progressBar.style.width = `${(destroyProgress / targetDestroyTime) * 100}%`;
                     }
-                    // Handle regular block destruction
-                    else if (destroyTargetBody) {
-                       const bodyIndex = placedConstructionBodies.indexOf(destroyTargetBody);
-                       if (bodyIndex !== -1) {
-                           // Adiciona a lógica de recompensa de troncos com base no estágio da árvore
-                           if (destroyTargetBody.userData.growthStage === 'media') {
-                               addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 1 });
-                           } else if (destroyTargetBody.userData.growthStage === 'arvore_adulta') {
-                               addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 3 });
-                           }
-                           // Adiciona tábuas de madeira ao inventário se o objeto destruído for um tronco ou tábua
-                           else if (destroyTargetBody.userData.type === 'tronco_arvore' || destroyTargetBody.userData.type === 'tábuas') {
-                               addItemToInventory(backpackItems, { name: woodenPlankItemName, quantity: 2 });
-                           }
-                           // Adiciona o item original ao inventário ao destruir
-                           if (destroyTargetBody.userData.type === 'cob' || destroyTargetBody.userData.type === 'piso') {
-                               addItemToInventory(backpackItems, { name: destroyTargetBody.userData.type, quantity: 1 });
-                           }
-                           updateBackpackDisplay();
-
-                           world.removeBody(destroyTargetBody);
-                           placedConstructionBodies.splice(bodyIndex, 1);
-                           scene.remove(destroyTargetMesh);
-                           if (destroyTargetMesh.isGroup) {
-                               destroyTargetMesh.children.forEach(child => {
-                                   if (child.geometry) child.geometry.dispose();
-                               });
-                           } else if (destroyTargetMesh.geometry) {
-                               destroyTargetMesh.geometry.dispose();
-                           }
-                           placedConstructionMeshesArrays.splice(bodyIndex, 1);
-                       }
-                    }
-                    createSmokeEffect(position);
-
-                    isDestroying = false;
-                    destroyProgress = 0;
-                    progressContainer.style.display = 'none';
-                    destroyTargetBody = null;
-                    destroyTargetMesh = null;
-
-                } else {
-                    // Atualiza a barra de progresso
-                    progressBar.style.width = `${(destroyProgress / targetDestroyTime) * 100}%`;
-                }
                 }
             } else {
                  // Reseta a barra de progresso se o usuário parar de destruir
+                if (isDestroying) { // Apenas se a destruição foi cancelada no último frame
+                    stopDestruction();
+                }
                 if (progressBar.style.width !== '0%') {
                     progressBar.style.width = '0%';
                 }
@@ -2262,8 +2311,8 @@
             // Isso garante que o jogador esteja sempre visualmente centralizado dentro do tile "principal".
             const playerX = playerBody.position.x; // Esta é a posição do jogador potencialmente envolvida
             const playerZ = playerBody.position.z;
-            const visualOffsetX = Math.round(playerX / worldSize) * worldSize;
-            const visualOffsetZ = Math.round(playerZ / worldSize) * worldSize;
+            visualOffsetX = Math.round(playerX / worldSize) * worldSize;
+            visualOffsetZ = Math.round(playerZ / worldSize) * worldSize;
 
             // Atualiza as posições das malhas do terreno com base na posição envolvida do jogador
             streetMeshes.forEach(tile => {
@@ -2276,18 +2325,50 @@
 
             // Atualiza as posições de todas as malhas visuais dos cubos/caixas
             collectibleBoxes.forEach(box => {
-                updateObjectVisuals(box.body, box.meshes, visualOffsetX, visualOffsetZ);
+                const distance = playerBody.position.distanceTo(box.body.position);
+                const isVisible = distance <= renderDistance;
+
+                box.meshes.forEach(m => {
+                    m.mesh.visible = isVisible;
+                });
+
+                if (isVisible) {
+                    updateObjectVisuals(box.body, box.meshes, visualOffsetX, visualOffsetZ);
+                }
             });
 
             // Atualiza as posições de todas as malhas visuais dos blocos colocados
             placedConstructionBodies.forEach((body, index) => {
-                // Cada corpo de bloco colocado agora tem apenas uma malha visual.
-                // Acessamos diretamente a malha no primeiro (e único) elemento do array de malhas para aquele corpo.
+                const distance = playerBody.position.distanceTo(body.position);
+                const isVisible = distance <= renderDistance;
+
                 const meshToUpdate = placedConstructionMeshesArrays[index][0].mesh;
-                meshToUpdate.position.x = body.position.x + placedConstructionMeshesArrays[index][0].offsetX - visualOffsetX;
-                meshToUpdate.position.y = body.position.y;
-                meshToUpdate.position.z = body.position.z + placedConstructionMeshesArrays[index][0].offsetZ - visualOffsetZ;
-                meshToUpdate.quaternion.copy(body.quaternion); // Mantém a rotação
+                meshToUpdate.visible = isVisible;
+
+                if (isVisible) {
+                    // Cada corpo de bloco colocado agora tem apenas uma malha visual.
+                    // Acessamos diretamente a malha no primeiro (e único) elemento do array de malhas para aquele corpo.
+                    meshToUpdate.position.x = body.position.x + placedConstructionMeshesArrays[index][0].offsetX - visualOffsetX;
+                    meshToUpdate.position.y = body.position.y;
+                    meshToUpdate.position.z = body.position.z + placedConstructionMeshesArrays[index][0].offsetZ - visualOffsetZ;
+                    meshToUpdate.quaternion.copy(body.quaternion); // Mantém a rotação
+                }
+            });
+
+            // NOVO: Atualiza a visibilidade e posição dos patches de textura
+            texturePatches.forEach(patch => {
+                const distance = playerBody.position.distanceTo(patch.position);
+                const isVisible = distance <= renderDistance;
+
+                patch.meshes.forEach(item => {
+                    item.mesh.visible = isVisible;
+                    if (isVisible) {
+                        const visualObject = item.mesh;
+                        visualObject.position.x = patch.position.x + item.offsetX - visualOffsetX;
+                        visualObject.position.y = patch.position.y;
+                        visualObject.position.z = patch.position.z + item.offsetZ - visualOffsetZ;
+                    }
+                });
             });
 
 


### PR DESCRIPTION
Adds a render distance of 100 meters for all dynamic objects, including collectible boxes, player-placed constructions, and texture patches.

In the main `animate` loop, the distance between the player and each object is calculated. If the distance exceeds the `renderDistance`, the `visible` property of the object's visual meshes is set to `false`.

This change also includes refactoring for texture patches to ensure they are created and managed in a way that is compatible with the new visibility system and the existing world-wrapping logic. The `playerBody` variable was also exposed to the global `window` object to allow for reliable frontend verification using Playwright teleportation.