### PR TITLE
Fix: Implement distance culling for collectible cubes

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -2337,16 +2337,17 @@
 
             // Atualiza as posições de todas as malhas visuais dos cubos/caixas
             collectibleBoxes.forEach(box => {
-                const distance = calculateWrappedDistance(playerBody.position, box.body.position);
-                const isVisible = distance <= renderDistance;
+                // Primeiro, atualiza as posições de todas as malhas para lidar com o envolvimento do mundo,
+                // garantindo que o efeito de mundo infinito funcione corretamente.
+                updateObjectVisuals(box.body, box.meshes, visualOffsetX, visualOffsetZ);
 
+                // Em seguida, itera sobre cada malha individual para verificar se ela está dentro
+                // da distância de renderização da câmera. Isso corrige o problema de objetos
+                // distantes aparecerem no horizonte.
                 box.meshes.forEach(m => {
-                    m.mesh.visible = isVisible;
+                    const distance = camera.position.distanceTo(m.mesh.position);
+                    m.mesh.visible = distance <= renderDistance;
                 });
-
-                if (isVisible) {
-                    updateObjectVisuals(box.body, box.meshes, visualOffsetX, visualOffsetZ);
-                }
             });
 
             // Atualiza as posições de todas as malhas visuais dos blocos colocados


### PR DESCRIPTION
The collectible cubes were previously visible on the horizon at all times, which was inconsistent with other objects in the world that are culled based on distance.

This change modifies the `animate` function to correctly cull the visual meshes of the collectible cubes. For each cube, it first calls `updateObjectVisuals` to correctly position all nine of its visual clones for the world-wrapping effect. It then iterates through each clone, calculates its individual distance from the camera, and sets its `visible` property based on the `renderDistance`.

This per-mesh culling approach ensures that both the world-wrapping illusion and the distance-based visibility are handled correctly.