### PR TITLE
Feat: Limit view distance to 200m with fog

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -442,7 +442,7 @@
         const islandRadius = 300; // NOVO: Raio da ilha
         const waterLevel = 0.2; // NOVO: Nível da água
         const seabedLevel = -20; // NOVO: Nível do fundo do mar
-        const renderDistance = 150; // Distância de renderização para objetos
+        const renderDistance = 200; // Distância de renderização para objetos
         // NOVO: A altura do terreno e a altura dos blocos de cob são agora as mesmas.
         const cobSize = 0.4;
         const islandSurfaceHeight = cobSize; // A altura da superfície visível da ilha
@@ -1260,9 +1260,10 @@
             // Configuração da Cena Three.js
             scene = new THREE.Scene();
             scene.background = new THREE.Color(0x87CEEB); // Cor de fundo: azul claro (céu)
+            scene.fog = new THREE.Fog(0x87CEEB, 100, 200); // Adiciona nevoeiro que começa a 100m e é total a 200m
 
             // Configuração da Câmera Three.js
-            camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+            camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 200);
             camera.rotation.order = 'YXZ'; // Define a ordem de rotação para guinada (Y), inclinação (X), rolagem (Z)
 
             // Configuração do Renderizador Three.js


### PR DESCRIPTION
This commit implements a limited render distance of 200 meters to enhance the game's atmosphere and performance.

Key changes:
- The `PerspectiveCamera`'s `far` property has been changed from 1000 to 200.
- `THREE.Fog` has been added to the scene, configured to start at 100m and be fully opaque at 200m, matching the sky color for a seamless transition.
- The `renderDistance` constant, used for manually culling objects, has been updated from 150 to 200 to align with the new camera and fog settings.

These changes ensure that the world fades out smoothly at a distance, providing a more polished visual experience.