### PR TITLE
Feat: Enhance world with seabed, fog, and block placement fix

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1585,9 +1585,12 @@
                 texture.wrapT = THREE.RepeatWrapping;
                 texture.repeat.set(1, 1); // Adjust as needed for leaves
                 treeLeavesMaterialMesh = new THREE.MeshStandardMaterial({ map: texture, transparent: true, alphaTest: 0.5 }); // alphaTest for transparency
+                // This is the last texture to load, so we can consider the game ready
+                window.gameIsReady = true;
             }, undefined, (error) => {
                 console.error('Erro ao carregar a textura das folhas da árvore:', error);
                 treeLeavesMaterialMesh = new THREE.MeshStandardMaterial({ color: 0x228B22 }); // Fallback dark green
+                window.gameIsReady = true; // Also set to true on error to not block the test
             });
 
             // Cria um corpo "grabber" invisível para segurar objetos
@@ -2084,18 +2087,12 @@
                     if (isPrimaryToolPlacing && isRightButtonPressed) {
                         // Aumenta o multiplicador para tornar a rotação mais responsiva
                         ghostBlockRotationY += deltaX * 0.15; // Rotação horizontal
-                        ghostBlockRotationX += deltaY * 0.15; // Rotação vertical
 
                         // Define o ângulo de snap (45 graus)
                         const snapAngle = Math.PI / 4; // 45 graus
 
                         // Arredonda ghostBlockRotationY para o múltiplo mais próximo de snapAngle
                         ghostBlockRotationY = Math.round(ghostBlockRotationY / snapAngle) * snapAngle;
-
-                        // Arredonda ghostBlockRotationX para o múltiplo mais próximo de snapAngle
-                        // Garante que permaneça dentro do intervalo de -PI/2 a PI/2 para rotação vertical
-                        ghostBlockRotationX = Math.round(ghostBlockRotationX / snapAngle) * snapAngle;
-                        ghostBlockRotationX = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, ghostBlockRotationX));
 
                     }
                     // Lógica de rotação do objeto segurado
@@ -2155,6 +2152,18 @@
             document.getElementById('backpackButton').addEventListener('click', openBackpack);
             document.getElementById('closeBackpackButton').addEventListener('click', closeBackpack);
 
+            // Expor variáveis para fins de teste
+            window.THREE = THREE;
+            window.CANNON = CANNON;
+            window.camera = camera;
+            window.playerBody = playerBody;
+            window.createPlaceableBlock = createPlaceableBlock;
+            window.islandSurfaceHeight = islandSurfaceHeight;
+            window.cobHeight = cobHeight;
+            window.cobItemName = cobItemName;
+            window.beltItems = beltItems;
+            window.selectedSlotIndex = selectedSlotIndex;
+            window.updateBeltDisplay = updateBeltDisplay;
         }
 
         // Função para lidar com o redimensionamento da janela
@@ -2493,9 +2502,9 @@
                     let placementPosition = new THREE.Vector3();
                     let tempPlacementQuaternion = new THREE.Quaternion(); // Usar um quaternion temporário
 
-                    // Declara manualRotationQuaternion aqui para que seja acessível
+                    // A rotação manual agora é apenas em torno do eixo Y
                     const manualRotationQuaternion = new THREE.Quaternion().setFromEuler(
-                        new THREE.Euler(ghostBlockRotationX, ghostBlockRotationY, 0, 'YXZ') // Ordem YXZ para rotação
+                        new THREE.Euler(0, ghostBlockRotationY, 0, 'YXZ')
                     );
 
                     // Define as dimensões do bloco atual para o ghost mesh
@@ -2571,11 +2580,8 @@
                                 placementPosition.y = basePosition.y; // Mantém a altura calculada
 
 
-                                // Alinha a rotação do bloco com a normal da superfície
-                                const surfaceAlignmentQuaternion = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), hitNormal);
-
-                                // Combina as rotações: primeiro o alinhamento da superfície, depois a rotação manual
-                                tempPlacementQuaternion.copy(surfaceAlignmentQuaternion).multiply(manualRotationQuaternion);
+                                // A rotação agora é apenas a rotação manual, garantindo que o bloco fique sempre na vertical
+                                tempPlacementQuaternion.copy(manualRotationQuaternion);
 
                                 // Verifica se a posição do ghost block não colide com o jogador
                                 const playerPos = new THREE.Vector3().copy(playerBody.position);


### PR DESCRIPTION
This commit introduces several major enhancements and bug fixes to the game world.

Features:
- World Size: The `worldSize` constant has been increased to 1200 and the `islandRadius` to 300, tripling the explorable area.
- Seabed: A seabed has been added at a depth of -20, and the island's geometry now extends down to meet it.
- View Distance: The camera's render distance is now limited to 200m, with `THREE.Fog` providing a smooth fade-out effect.

Bug Fixes:
- Block Placement: The logic for placing blocks has been corrected. Blocks no longer align with the surface they are placed on, ensuring they always remain upright and only rotate based on the player's manual horizontal input. This was achieved by removing the surface normal alignment and vertical rotation logic.
- Asset Loading for Tests: A `window.gameIsReady` flag was added to signal when all game assets have been loaded, making Playwright tests more reliable.
- Island Positioning: Corrected the island's visual and physical positioning to prevent it from disappearing or being misplaced after its height was extended.