### PR TITLE
This commit adds a physics body for the seabed to prevent the player …

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -381,6 +381,7 @@
 
         let waterMeshes = []; // NOVO: Array para armazenar múltiplas malhas visuais da água
         let seabedMeshes = []; // NOVO: Array para armazenar múltiplas malhas visuais do fundo do mar
+        let seabedBody; // NOVO: Corpo de física para o fundo do mar
 
         // NOVO: Array para rastrear todas as caixas colecionáveis (corpos e malhas)
         let collectibleBoxes = [];
@@ -1461,6 +1462,13 @@
                 }
             }
 
+            // NOVO: Cria o corpo de física para o fundo do mar
+            const seabedShape = new CANNON.Plane();
+            seabedBody = new CANNON.Body({ mass: 0, shape: seabedShape, material: islandMaterial });
+            seabedBody.quaternion.setFromAxisAngle(new CANNON.Vec3(1, 0, 0), -Math.PI / 2); // Rotaciona o plano para ficar horizontal
+            seabedBody.position.y = seabedLevel; // Define a altura do fundo do mar
+            world.addBody(seabedBody);
+
 
             // A rua foi removida, então o código relacionado a ela foi excluído.
 
@@ -1487,7 +1495,7 @@
             playerBody.addEventListener('collide', (event) => {
                 // canJump é verdadeiro APENAS se o corpo colidido NÃO for o objeto que está sendo segurado
                 // A lista de corpos "chão" agora inclui apenas superfícies que podem ser pisadas
-                const allGroundBodies = [islandBody, ...collectibleBoxes.map(b => b.body), ...placedConstructionBodies];
+                const allGroundBodies = [islandBody, seabedBody, ...collectibleBoxes.map(b => b.body), ...placedConstructionBodies];
                 if (event.body !== pickedObjectBody && allGroundBodies.includes(event.body)) {
                     canJump = true;
                 }
@@ -2799,7 +2807,7 @@
             // Verifica colisão com terreno (rua), estrada, cubos e blocos
             world.raycastAny(rayOriginLow, rayTargetLow, {}, rayResultStep);
             // A lista de corpos "chão" para subida de degraus
-            const stepClimbGroundBodies = [islandBody, ...collectibleBoxes.map(b => b.body), ...placedConstructionBodies];
+            const stepClimbGroundBodies = [islandBody, seabedBody, ...collectibleBoxes.map(b => b.body), ...placedConstructionBodies];
             if (rayResultStep.hasHit && stepClimbGroundBodies.includes(rayResultStep.body)) {
                 hitLow = true;
             }


### PR DESCRIPTION
…and other objects from falling through.

A new static CANNON.Body with a CANNON.Plane shape is created at the specified `seabedLevel`. This body is assigned the existing `islandMaterial`, which ensures it correctly collides with the player and other dynamic objects (like boxes) through the pre-existing ContactMaterial definitions.

The new seabed body has also been integrated into the game's ground collision logic, allowing for consistent interactions like jumping and step-climbing.