### PR TITLE
Implement two-stage Escape key for mouse release and menu access

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1080,6 +1080,7 @@
         let isDrivingRaft = false; // NOVO: Flag para modo de direção da jangada
         let currentRaftBody = null; // NOVO: Referência à jangada atual sendo dirigida
         let pointerLockExitForBackpack = false; // NOVO: Flag para controlar a saída do pointer lock devido à mochila
+        let isEscExit = false; // NOVO: Flag para controlar a saída do pointer lock via tecla ESC
         let isWorldReady = false; window.isWorldReady = isWorldReady; // NOVO: Flag para rastrear se o mundo está pronto para interações
         let nextMeteorCheckTime = -1; // NOVO: Próximo horário de checagem do meteoro
         let currentDayForMeteor = -1; // NOVO: Dia atual para controle de checagem
@@ -5054,6 +5055,7 @@
                         // Se o jogo estiver a correr e o ponteiro estiver bloqueado,
                         // libertamos o bloqueio do ponteiro. O evento 'pointerlockchange'
                         // irá então tratar de mostrar o menu.
+                        isEscExit = true;
                         document.exitPointerLock();
                     } else {
                         // Se o jogo não estiver pausado e o ponteiro não estiver bloqueado
@@ -5306,12 +5308,12 @@
                         ghostBlockMesh.visible = false; // Oculta o ghost block
                     }
 
-                    // Se o bloqueio do ponteiro foi perdido e NÃO foi por causa da mochila
-                    if (!pointerLockExitForBackpack) {
+                    // Se o bloqueio do ponteiro foi perdido e NÃO foi por causa da mochila ou tecla ESC
+                    if (!pointerLockExitForBackpack && !isEscExit) {
                         showOptionsScreen(); // Isso irá definir gamePaused como true e mostrar o menu
                     }
-                    // O cinto de inventário deve ser escondido APENAS se não for por causa da mochila
-                    if (inventoryBeltElement && !pointerLockExitForBackpack) {
+                    // O cinto de inventário deve ser escondido APENAS se não for por causa da mochila ou tecla ESC
+                    if (inventoryBeltElement && !pointerLockExitForBackpack && !isEscExit) {
                         inventoryBeltElement.style.visibility = 'hidden';
                         inventoryBeltElement.style.opacity = '0';
                     }
@@ -5329,6 +5331,7 @@
                 }
                 // Sempre reseta a flag após o processamento do pointerlockchange
                 pointerLockExitForBackpack = false;
+                isEscExit = false;
             });
 
             // NOVO: Listener de mousedown consolidado
@@ -7459,7 +7462,7 @@
                 // O "fantasma verde" da terra foi removido a pedido do usuário
                 const isShowingTerraGhost = (isPrimaryToolDestroying && currentBlockType === dirtItemName);
                 const isTerra = currentBlockType === dirtItemName;
-                if ((isPrimaryToolPlacing || isShowingTerraGhost) && !gamePaused && !isTerra) {
+                if ((isPrimaryToolPlacing || isShowingTerraGhost) && !gamePaused && !isTerra && document.pointerLockElement === renderer.domElement) {
                     ghostBlockMesh.visible = true; // Garante que o ghost block esteja visível
 
                     const intersects = mainIntersects;

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,7 @@
 {
-  "status": "passed",
-  "failedTests": []
+  "status": "failed",
+  "failedTests": [
+    "dc5f3c5f1bc325246ca1-96ff5b0a5505ca6af125",
+    "dc5f3c5f1bc325246ca1-e27f3b3ddb64e2bd4445"
+  ]
 }

--- a/test-results/tests-hud_weather-Weather--07bed-weather-toggle-button-works/error-context.md
+++ b/test-results/tests-hud_weather-Weather--07bed-weather-toggle-button-works/error-context.md
@@ -1,0 +1,90 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: tests/hud_weather.spec.js >> Weather HUD Button >> HUD weather toggle button works
+- Location: tests/hud_weather.spec.js:12:5
+
+# Error details
+
+```
+Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:8080/index.htm
+Call log:
+  - navigating to "http://localhost:8080/index.htm", waiting until "load"
+
+```
+
+# Test source
+
+```ts
+  1  | const { test, expect } = require('@playwright/test');
+  2  |
+  3  | test.describe('Weather HUD Button', () => {
+  4  |     test.beforeEach(async ({ page }) => {
+  5  |         test.setTimeout(120000);
+> 6  |         await page.goto('http://localhost:8080/index.htm');
+     |                    ^ Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:8080/index.htm
+  7  |         await page.click('#startButton');
+  8  |         await page.waitForFunction(() => window.isWorldReady === true, { timeout: 90000 });
+  9  |         await page.evaluate(() => { window.gamePaused = false; });
+  10 |     });
+  11 |
+  12 |     test('HUD weather toggle button works', async ({ page }) => {
+  13 |         // Check initial state
+  14 |         const initialTargetRain = await page.evaluate(() => window.targetRainIntensity);
+  15 |         expect(initialTargetRain).toBe(0);
+  16 |
+  17 |         const initialHudText = await page.textContent('#hudWeatherText');
+  18 |         expect(initialHudText).toBe('Sol');
+  19 |
+  20 |         // Click HUD toggle button
+  21 |         await page.evaluate(() => {
+  22 |             document.getElementById('hudWeatherToggle').click();
+  23 |         });
+  24 |
+  25 |         // Verify state change
+  26 |         const finalTargetRain = await page.evaluate(() => window.targetRainIntensity);
+  27 |         expect(finalTargetRain).toBeGreaterThan(0);
+  28 |
+  29 |         const finalHudText = await page.textContent('#hudWeatherText');
+  30 |         expect(finalHudText).toBe('Chuva');
+  31 |
+  32 |         // Toggle back to sun
+  33 |         await page.evaluate(() => {
+  34 |             document.getElementById('hudWeatherToggle').click();
+  35 |         });
+  36 |         const backToSunRain = await page.evaluate(() => window.targetRainIntensity);
+  37 |         expect(backToSunRain).toBe(0);
+  38 |         expect(await page.textContent('#hudWeatherText')).toBe('Sol');
+  39 |     });
+  40 |
+  41 |     test('Escape key releases mouse but keeps HUD visible; Pressing Escape again opens menu', async ({ page }) => {
+  42 |         const hudButtons = page.locator('#hudButtons');
+  43 |         await expect(hudButtons).toBeVisible();
+  44 |
+  45 |         // Press Escape - should release mouse but NOT hide HUD (new behavior)
+  46 |         await page.keyboard.press('Escape');
+  47 |         await page.waitForFunction(() => document.pointerLockElement === null);
+  48 |         await expect(hudButtons).toBeVisible();
+  49 |
+  50 |         // Verify menu is NOT active yet
+  51 |         const optionsScreen = page.locator('#optionsScreen');
+  52 |         await expect(optionsScreen).not.toHaveClass(/active/);
+  53 |
+  54 |         // Press Escape again - should now open the menu
+  55 |         await page.keyboard.press('Escape');
+  56 |         await expect(optionsScreen).toHaveClass(/active/);
+  57 |         await expect(hudButtons).toBeHidden();
+  58 |
+  59 |         // Close menu
+  60 |         await page.click('#resumeButton');
+  61 |         await expect(hudButtons).toBeVisible();
+  62 |         await expect(optionsScreen).not.toHaveClass(/active/);
+  63 |     });
+  64 | });
+  65 |
+```

--- a/test-results/tests-hud_weather-Weather--701a3-ing-Escape-again-opens-menu/error-context.md
+++ b/test-results/tests-hud_weather-Weather--701a3-ing-Escape-again-opens-menu/error-context.md
@@ -1,0 +1,90 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: tests/hud_weather.spec.js >> Weather HUD Button >> Escape key releases mouse but keeps HUD visible; Pressing Escape again opens menu
+- Location: tests/hud_weather.spec.js:41:5
+
+# Error details
+
+```
+Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:8080/index.htm
+Call log:
+  - navigating to "http://localhost:8080/index.htm", waiting until "load"
+
+```
+
+# Test source
+
+```ts
+  1  | const { test, expect } = require('@playwright/test');
+  2  |
+  3  | test.describe('Weather HUD Button', () => {
+  4  |     test.beforeEach(async ({ page }) => {
+  5  |         test.setTimeout(120000);
+> 6  |         await page.goto('http://localhost:8080/index.htm');
+     |                    ^ Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:8080/index.htm
+  7  |         await page.click('#startButton');
+  8  |         await page.waitForFunction(() => window.isWorldReady === true, { timeout: 90000 });
+  9  |         await page.evaluate(() => { window.gamePaused = false; });
+  10 |     });
+  11 |
+  12 |     test('HUD weather toggle button works', async ({ page }) => {
+  13 |         // Check initial state
+  14 |         const initialTargetRain = await page.evaluate(() => window.targetRainIntensity);
+  15 |         expect(initialTargetRain).toBe(0);
+  16 |
+  17 |         const initialHudText = await page.textContent('#hudWeatherText');
+  18 |         expect(initialHudText).toBe('Sol');
+  19 |
+  20 |         // Click HUD toggle button
+  21 |         await page.evaluate(() => {
+  22 |             document.getElementById('hudWeatherToggle').click();
+  23 |         });
+  24 |
+  25 |         // Verify state change
+  26 |         const finalTargetRain = await page.evaluate(() => window.targetRainIntensity);
+  27 |         expect(finalTargetRain).toBeGreaterThan(0);
+  28 |
+  29 |         const finalHudText = await page.textContent('#hudWeatherText');
+  30 |         expect(finalHudText).toBe('Chuva');
+  31 |
+  32 |         // Toggle back to sun
+  33 |         await page.evaluate(() => {
+  34 |             document.getElementById('hudWeatherToggle').click();
+  35 |         });
+  36 |         const backToSunRain = await page.evaluate(() => window.targetRainIntensity);
+  37 |         expect(backToSunRain).toBe(0);
+  38 |         expect(await page.textContent('#hudWeatherText')).toBe('Sol');
+  39 |     });
+  40 |
+  41 |     test('Escape key releases mouse but keeps HUD visible; Pressing Escape again opens menu', async ({ page }) => {
+  42 |         const hudButtons = page.locator('#hudButtons');
+  43 |         await expect(hudButtons).toBeVisible();
+  44 |
+  45 |         // Press Escape - should release mouse but NOT hide HUD (new behavior)
+  46 |         await page.keyboard.press('Escape');
+  47 |         await page.waitForFunction(() => document.pointerLockElement === null);
+  48 |         await expect(hudButtons).toBeVisible();
+  49 |
+  50 |         // Verify menu is NOT active yet
+  51 |         const optionsScreen = page.locator('#optionsScreen');
+  52 |         await expect(optionsScreen).not.toHaveClass(/active/);
+  53 |
+  54 |         // Press Escape again - should now open the menu
+  55 |         await page.keyboard.press('Escape');
+  56 |         await expect(optionsScreen).toHaveClass(/active/);
+  57 |         await expect(hudButtons).toBeHidden();
+  58 |
+  59 |         // Close menu
+  60 |         await page.click('#resumeButton');
+  61 |         await expect(hudButtons).toBeVisible();
+  62 |         await expect(optionsScreen).not.toHaveClass(/active/);
+  63 |     });
+  64 | });
+  65 |
+```

--- a/tests/hud_weather.spec.js
+++ b/tests/hud_weather.spec.js
@@ -38,16 +38,27 @@ test.describe('Weather HUD Button', () => {
         expect(await page.textContent('#hudWeatherText')).toBe('Sol');
     });
 
-    test('HUD buttons are hidden when menu is open', async ({ page }) => {
+    test('Escape key releases mouse but keeps HUD visible; Pressing Escape again opens menu', async ({ page }) => {
         const hudButtons = page.locator('#hudButtons');
         await expect(hudButtons).toBeVisible();
 
-        // Open menu
+        // Press Escape - should release mouse but NOT hide HUD (new behavior)
         await page.keyboard.press('Escape');
+        await page.waitForFunction(() => document.pointerLockElement === null);
+        await expect(hudButtons).toBeVisible();
+
+        // Verify menu is NOT active yet
+        const optionsScreen = page.locator('#optionsScreen');
+        await expect(optionsScreen).not.toHaveClass(/active/);
+
+        // Press Escape again - should now open the menu
+        await page.keyboard.press('Escape');
+        await expect(optionsScreen).toHaveClass(/active/);
         await expect(hudButtons).toBeHidden();
 
         // Close menu
         await page.click('#resumeButton');
         await expect(hudButtons).toBeVisible();
+        await expect(optionsScreen).not.toHaveClass(/active/);
     });
 });


### PR DESCRIPTION
Modified the 'Escape' key logic in `index.htm` to allow a two-stage exit from camera control. The first press now only releases the pointer lock, enabling the player to click on HUD elements like the settings button (which now displays 'Esc') and the weather toggle. A subsequent press of the 'Escape' key while the mouse is free will trigger the pause menu as before. Additionally, the construction ghost block is automatically hidden when the mouse is released to avoid visual clutter during UI interaction. Automated tests in `tests/hud_weather.spec.js` have been updated to verify this new workflow.

---
*PR created automatically by Jules for task [16072971810283077219](https://jules.google.com/task/16072971810283077219) started by @Armandodecampos*