### PR TITLE
Implement Cloud Proximity Damage and Altitude Limits

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -8472,12 +8472,23 @@
                 const playerPos = playerBody.position;
                 // isUnderwater logic: camera below water level and there is water at camera position
                 const isUnderwater = camera.position.y < waterLevel && (typeof hasWaterAt === 'function' ? hasWaterAt(camera.position.x, camera.position.z) : true);
-                const isHighAltitude = playerPos.y > 5000;
-                const isInstantDeathAltitude = playerPos.y > 10000;
+
+                // NOVO: Verifica proximidade com nuvens
+                let isNearCloud = false;
+                for (let i = 0; i < clouds.length; i++) {
+                    const cloud = clouds[i];
+                    if (calculateWrappedDistance(playerPos, cloud.mesh.position) < 15) {
+                        isNearCloud = true;
+                        break;
+                    }
+                }
+
+                const isHighAltitude = playerPos.y > 200;
+                const isInstantDeathAltitude = playerPos.y > 500;
 
                 if (isInstantDeathAltitude) {
                     playerHealth = 0;
-                } else if (isUnderwater || isHighAltitude) {
+                } else if (isUnderwater || isHighAltitude || isNearCloud) {
                     playerBreath -= delta * 15; // Diminui folego (aprox 6.6s total)
                 } else {
                     playerBreath += delta * 30; // Recupera folego mais rápido (aprox 3.3s total)

--- a/tests/cloud_damage.spec.js
+++ b/tests/cloud_damage.spec.js
@@ -1,0 +1,61 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Cloud Damage System', () => {
+    test.beforeEach(async ({ page }) => {
+        test.setTimeout(120000);
+        await page.goto('http://localhost:8080/index.htm');
+        await page.click('#startButton');
+        await page.waitForFunction(() => window.isWorldReady === true, { timeout: 90000 });
+        await page.evaluate(() => { window.gamePaused = false; });
+    });
+
+    test('player takes breath damage near clouds', async ({ page }) => {
+        // Force spawn a cloud at a known position for the test
+        await page.evaluate(() => {
+            // Clear existing clouds
+            window.clouds.forEach(c => window.scene.remove(c.mesh));
+            window.clouds.length = 0;
+
+            // Spawn one cloud at a specific position
+            window.spawnCloud(true);
+            const cloud = window.clouds[0];
+            cloud.mesh.position.set(0, 100, 0);
+            cloud.speed = 0; // Stop it from moving
+
+            // Teleport player near the cloud
+            window.playerBody.position.set(5, 100, 5); // Distance is sqrt(5^2 + 5^2) = ~7.07 < 15
+            window.playerBody.velocity.set(0, 0, 0);
+        });
+
+        // Check breath after some time
+        // Breath decreases at 15 units/s. Wait 1 second.
+        await page.waitForTimeout(2000);
+        let breath = await page.evaluate(() => window.playerBreath);
+        expect(breath).toBeLessThan(100);
+    });
+
+    test('player takes breath damage at high altitude (>200)', async ({ page }) => {
+        await page.evaluate(() => {
+            window.playerBody.position.set(0, 250, 0);
+            window.playerBody.velocity.set(0, 0, 0);
+        });
+
+        await page.waitForTimeout(2000);
+        let breath = await page.evaluate(() => window.playerBreath);
+        expect(breath).toBeLessThan(100);
+    });
+
+    test('player dies instantly at very high altitude (>500)', async ({ page }) => {
+        await page.evaluate(() => {
+            window.playerBody.position.set(0, 600, 0);
+            window.playerBody.velocity.set(0, 0, 0);
+        });
+
+        await page.waitForTimeout(500);
+        let health = await page.evaluate(() => window.playerHealth);
+        expect(health).toBe(0);
+
+        let isFainted = await page.evaluate(() => window.isFainted);
+        expect(isFainted).toBe(true);
+    });
+});


### PR DESCRIPTION
This change introduces a new survival mechanic where the player takes breath damage when flying near clouds or reaching high altitudes (above 200m). Additionally, reaching extreme altitudes (above 500m) now results in instant death. These changes enhance the environmental hazards and define clear vertical boundaries for the game world.

Key changes:
- Modified the `animate` loop in `index.htm` to include a proximity check for the `clouds` array.
- Updated survival logic to deplete `playerBreath` when `isNearCloud` is true.
- Adjusted `isHighAltitude` from 5000 to 200.
- Adjusted `isInstantDeathAltitude` from 10000 to 500.
- Created `tests/cloud_damage.spec.js` to ensure the mechanics work as intended.

---
*PR created automatically by Jules for task [11862351844029091170](https://jules.google.com/task/11862351844029091170) started by @Armandodecampos*