### PR TITLE
Implement swimming surfacing mechanic and disable jumping in water

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -5297,20 +5297,15 @@
                         if (event.repeat) return; // Impede pulos múltiplos por segurar a tecla (handled by boost logic)
                         const playerBottomY = playerBody.position.y - (isCrouching ? crouchRadius : playerRadius);
                         const isInWater = playerBottomY < waterLevel && hasWaterAt(playerBody.position.x, playerBody.position.z);
-                        if (canJump || isInWater) {
+                        if (canJump && !isInWater) {
                             // Inicia o pulo proporcional
                             isJumpBoosting = true;
                             jumpBoostTimer = 0;
 
                             // Impulso de salto inicial (mínimo)
-                            const jumpImpulse = isInWater ? 1800 : 600;
+                            const jumpImpulse = 600;
                             playerBody.applyImpulse(new CANNON.Vec3(0, jumpImpulse, 0));
                             canJump = false; window.canJump = false; // Impede pulos múltiplos
-                            if (isInWater) {
-                                isWaterJumping = true;
-                                // Desativa temporariamente as forças de flutuação para permitir que o salto tenha efeito
-                                setTimeout(() => { isWaterJumping = false; }, 500); // Reativa após meio segundo
-                            }
                         }
                     }
                 }
@@ -8037,16 +8032,19 @@
 
             // Lógica de física da água e mergulho
             if (isInWater && !isWaterJumping) {
-                // Lógica de Mergulho: Se 'c' for pressionado, define uma velocidade para baixo
+                const targetY = waterLevel + (isCrouching ? crouchRadius : playerRadius); // Flutua na superfície
+
+                // Lógica de Mergulho e Subida:
                 if (keysPressed['c']) {
                     playerBody.velocity.y = -walkSpeed; // Mergulha com a velocidade de caminhada
+                } else if (keysPressed[' '] && playerBody.position.y < targetY) {
+                    playerBody.velocity.y = walkSpeed; // Sobe para a superfície com a velocidade de caminhada
                 } else {
-                    // --- Lógica de Flutuação Estável (quando não está a mergulhar ou a saltar da água) ---
+                    // --- Lógica de Flutuação Estável (quando não está a mergulhar, a subir ou a saltar da água) ---
                     const K_SPRING = 250;
                     const C_DAMPING = 35;
                     const gravityMagnitude = Math.abs(world.gravity.y);
                     const antiGravityForce = playerBody.mass * gravityMagnitude;
-                    const targetY = waterLevel + (isCrouching ? crouchRadius : playerRadius); // Flutua na superfície
                     const displacement = playerBody.position.y - targetY;
                     const springForce = -K_SPRING * displacement;
                     const verticalVelocity = playerBody.velocity.y;
@@ -8632,6 +8630,7 @@
             Object.defineProperty(window, 'playerHealth', { get: () => playerHealth, set: (v) => { playerHealth = v; } });
             Object.defineProperty(window, 'playerBreath', { get: () => playerBreath, set: (v) => { playerBreath = v; } });
             Object.defineProperty(window, 'isFainted', { get: () => isFainted, set: (v) => { isFainted = v; } });
+            Object.defineProperty(window, 'isJumpBoosting', { get: () => isJumpBoosting, set: (v) => { isJumpBoosting = v; } });
             window.faintPlayer = faintPlayer;
             window.respawnPlayer = respawnPlayer;
             Object.defineProperty(window, 'renderDistance', {

--- a/tests/swimming.spec.js
+++ b/tests/swimming.spec.js
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+
+test('Swimming and jumping logic verification', async ({ page }) => {
+  test.setTimeout(120000);
+  await page.goto('http://localhost:8080/index.htm');
+  await page.click('#startButton');
+
+  // Wait for world to be ready
+  await page.waitForFunction(() => window.isWorldReady === true, { timeout: 90000 });
+
+  // 1. Verify that jumping on land still works (at least doesn't crash and changes velocity)
+  // Initially at (0, 10, 0), which is above waterLevel (-8)
+  const initialVelocityY = await page.evaluate(() => window.playerBody.velocity.y);
+
+  // Press Space to jump
+  await page.keyboard.press(' ');
+
+  // Check if velocity changed upwards
+  const jumpVelocityY = await page.evaluate(() => window.playerBody.velocity.y);
+  expect(jumpVelocityY).toBeGreaterThan(initialVelocityY);
+
+  // 2. Teleport player into water and verify surfacing logic
+  await page.evaluate(() => {
+    // waterLevel is -8. TargetY is around -6.5 (radius 1.5)
+    // Put player deep in water at (400, -15, 400) - far from island center (0,0) to be in water
+    window.playerBody.position.set(400, -15, 400);
+    window.playerBody.velocity.set(0, 0, 0);
+  });
+
+  // Wait a bit for physics to settle/detect water
+  await page.waitForTimeout(500);
+
+  // Verify isInWater is true
+  const isInWater = await page.evaluate(() => {
+    const waterLevel = window.waterLevel || -8.0;
+    const playerRadius = window.playerRadius || 1.5;
+    const playerBottomY = window.playerBody.position.y - playerRadius;
+    return playerBottomY < waterLevel;
+  });
+  expect(isInWater).toBe(true);
+
+  // Press and hold Space to swim up
+  await page.keyboard.down(' ');
+
+  // Wait a few frames for velocity to be applied in animate loop
+  await page.waitForTimeout(200);
+
+  const swimmingVelocityY = await page.evaluate(() => window.playerBody.velocity.y);
+  const walkSpeed = await page.evaluate(() => window.walkSpeed || 5);
+
+  // Velocity should be exactly walkSpeed (5) due to our assignment in animate loop
+  expect(swimmingVelocityY).toBeCloseTo(walkSpeed, 1);
+
+  await page.keyboard.up(' ');
+
+  // 3. Verify that player doesn't "jump" out of water with a single press
+  // Reset position in water
+  await page.evaluate(() => {
+    window.playerBody.position.set(400, -15, 400);
+    window.playerBody.velocity.set(0, 0, 0);
+  });
+  await page.waitForTimeout(200);
+
+  // Press Space briefly (using press)
+  await page.keyboard.press(' ');
+
+  // isJumpBoosting should be false because we added !isInWater to the condition
+  const isJumpBoosting = await page.evaluate(() => window.isJumpBoosting);
+  expect(isJumpBoosting).toBe(false);
+});


### PR DESCRIPTION
This change improves the player's interaction with water by replacing the standard jump (which felt unnatural in water) with a swimming surfacing mechanic. When submerged, holding the Space bar will now move the player upward to the surface at a constant speed. Jumping is now correctly restricted to land only.

---
*PR created automatically by Jules for task [3242736964162597835](https://jules.google.com/task/3242736964162597835) started by @Armandodecampos*