### PR TITLE
Reduce initial boxes from 3 to 1

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -4850,8 +4850,6 @@
 
                 // Cria as caixas iniciais DENTRO do callback
                 createBox(new THREE.Vector3(0, cubeSize / 2 + getSurfaceHeight(0, -10), -10));
-                createBox(new THREE.Vector3(5, cubeSize / 2 + getSurfaceHeight(5, -10), -10));
-                createBox(new THREE.Vector3(-5, cubeSize / 2 + getSurfaceHeight(-5, -10), -10));
             });
 
             // Cria o ghost block (transparente)


### PR DESCRIPTION
The user requested to have only one box appear instead of three at the start of the game. I identified the three `createBox` calls in the `index.htm` file that were responsible for spawning the initial boxes and removed two of them, leaving only the central one. I verified the change by running a Playwright script that confirms only one box of type 'caixote' exists in the `collectibleBoxes` array after initialization. All existing automated tests passed.

---
*PR created automatically by Jules for task [7428473984880513869](https://jules.google.com/task/7428473984880513869) started by @Armandodecampos*