### PR TITLE
Increase hand slots to 9 and remove empty hand icon

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -227,8 +227,8 @@
             white-space: pre-wrap;
         }
         .slot {
-            width: 100px;
-            height: 100px;
+            width: 60px;
+            height: 60px;
             border: 2px solid #555;
             border-radius: 50%;
             background-color: rgba(255, 255, 255, 0.1);
@@ -237,7 +237,7 @@
             justify-content: center;
             align-items: center;
             color: #bbb;
-            font-size: 0.9em;
+            font-size: 0.8em;
             transition: border-color 0.1s ease-in-out, background-color 0.1s ease-in-out;
             position: relative; /* Para posicionar a quantidade */
             cursor: grab; /* Cursor para indicar que é arrastável */
@@ -262,11 +262,11 @@
             padding: 5px; /* Adiciona um pequeno preenchimento */
             border-radius: 50%;
         }
-        .slot-key-bind { /* Estilo para as letras de atalho (Q, E) */
+        .slot-key-bind { /* Estilo para as letras de atalho (1 a 9) */
             position: absolute;
-            top: 2px;
-            left: 4px;
-            font-size: 0.7em;
+            top: 1px;
+            left: 3px;
+            font-size: 0.6em;
             color: white;
             text-shadow: 1px 1px 2px rgba(0,0,0,0.7);
             font-weight: bold;
@@ -276,10 +276,10 @@
         #backpackButton {
             background-color: #8B4513; /* Brown color */
             color: white;
-            padding: 10px 15px;
+            padding: 8px 12px;
             border: none;
             border-radius: 8px;
-            font-size: 1.2em;
+            font-size: 1.0em;
             cursor: pointer;
             transition: background-color 0.3s ease;
         }
@@ -1188,8 +1188,8 @@
         // Variáveis para o cinto de inventário
         let inventoryBeltElement;
         let slots = []; // Array para armazenar os elementos dos slots
-        const numBeltSlots = 2; // Número total de slots do cinto (apenas 2 agora)
-        let selectedSlotIndex = 0; // NOVO: Índice do slot selecionado (0 para esquerdo, 1 para direito)
+        const numBeltSlots = 9; // Número total de slots do cinto (agora 9)
+        let selectedSlotIndex = 0; // NOVO: Índice do slot selecionado (0 a 8)
 
         // Variáveis para o sistema de mochila
         let backpackModal;
@@ -1939,7 +1939,7 @@
             if (containerType === 'belt') {
                 const keyBindSpan = document.createElement('span');
                 keyBindSpan.classList.add('slot-key-bind');
-                keyBindSpan.textContent = (index === 0) ? '1' : '2';
+                keyBindSpan.textContent = (index + 1).toString();
                 slotDiv.appendChild(keyBindSpan);
             }
 
@@ -1972,15 +1972,6 @@
                     quantitySpan.textContent = item.quantity;
                     slotDiv.appendChild(quantitySpan);
                 }
-            } else if (containerType === 'belt') {
-                const img = document.createElement('img');
-                img.src = handImageURL;
-                img.classList.add('slot-icon');
-                // Inverte a imagem horizontalmente se estiver no slot esquerdo (índice 0)
-                if (index === 0) {
-                    img.style.transform = 'scaleX(-1)';
-                }
-                slotDiv.appendChild(img);
             } else if (isList) {
                 const nameSpan = document.createElement('span');
                 nameSpan.classList.add('slot-name');
@@ -2070,11 +2061,13 @@
             weightNeedsUpdate = true;
             inventoryBeltElement.innerHTML = ''; // Limpa os slots existentes
 
-            // Slot esquerdo (índice 0)
-            const leftSlotDiv = renderSlot(beltItems[0], 0, 'belt');
-            inventoryBeltElement.appendChild(leftSlotDiv);
+            // Renderiza todos os slots do cinto
+            for (let i = 0; i < numBeltSlots; i++) {
+                const slotDiv = renderSlot(beltItems[i], i, 'belt');
+                inventoryBeltElement.appendChild(slotDiv);
+            }
 
-            // Botão da mochila
+            // Botão da mochila ao final
             const backpackButton = document.createElement('button');
             backpackButton.id = 'backpackButton';
             const backpackIcon = document.createElement('i');
@@ -2082,10 +2075,6 @@
             backpackButton.appendChild(backpackIcon);
             backpackButton.addEventListener('click', openBackpack);
             inventoryBeltElement.appendChild(backpackButton);
-
-            // Slot direito (índice 1)
-            const rightSlotDiv = renderSlot(beltItems[1], 1, 'belt');
-            inventoryBeltElement.appendChild(rightSlotDiv);
 
             // Atualiza a referência aos elementos dos slots para drag and drop
             slots = Array.from(inventoryBeltElement.querySelectorAll('.slot'));
@@ -5278,15 +5267,12 @@
                     }
                 }
 
-                // NOVO: Seleção de slots com 1 e 2
+                // NOVO: Seleção de slots com 1 a 9
                 if (!gamePaused && !backpackModal.classList.contains('active')) {
-                    if (event.key === '1') {
-                        if (selectedSlotIndex !== 0) stopDestruction();
-                        selectedSlotIndex = 0;
-                        updateBeltDisplay();
-                    } else if (event.key === '2') {
-                        if (selectedSlotIndex !== 1) stopDestruction();
-                        selectedSlotIndex = 1;
+                    if (event.key >= '1' && event.key <= '9') {
+                        const newIndex = parseInt(event.key) - 1;
+                        if (selectedSlotIndex !== newIndex) stopDestruction();
+                        selectedSlotIndex = newIndex;
                         updateBeltDisplay();
                     }
 

--- a/tests/hand_slots.spec.js
+++ b/tests/hand_slots.spec.js
@@ -1,6 +1,6 @@
 const { test, expect } = require('@playwright/test');
 
-test('Hand slots selection with 1 and 2', async ({ page }) => {
+test('Hand slots selection with 1 through 9', async ({ page }) => {
     test.setTimeout(60000);
     await page.goto('http://localhost:8080/index.htm');
     await page.click('#startButton');
@@ -8,50 +8,49 @@ test('Hand slots selection with 1 and 2', async ({ page }) => {
     // Wait for world to be ready
     await page.waitForFunction(() => window.isWorldReady === true);
 
-    // Directly set selectedSlotIndex via page.evaluate
-    await page.evaluate(() => {
-        window.selectedSlotIndex = 1;
-        window.updateBeltDisplay();
-    });
+    // Test selection of all 9 slots
+    for (let i = 1; i <= 9; i++) {
+        await page.evaluate((slot) => {
+            const event = new KeyboardEvent('keydown', { key: slot.toString() });
+            window.dispatchEvent(event);
+        }, i);
 
-    let selectedSlot = await page.evaluate(() => window.selectedSlotIndex);
-    expect(selectedSlot).toBe(1);
-
-    // Now test if keys work by triggering them manually in the page context
-    await page.evaluate(() => {
-        const event1 = new KeyboardEvent('keydown', { key: '1' });
-        window.dispatchEvent(event1);
-    });
-
-    selectedSlot = await page.evaluate(() => window.selectedSlotIndex);
-    expect(selectedSlot).toBe(0);
-
-    await page.evaluate(() => {
-        const event2 = new KeyboardEvent('keydown', { key: '2' });
-        window.dispatchEvent(event2);
-    });
-
-    selectedSlot = await page.evaluate(() => window.selectedSlotIndex);
-    expect(selectedSlot).toBe(1);
-
-    // Verify 'q' and 'e' no longer work
-    await page.evaluate(() => {
-        const eventQ = new KeyboardEvent('keydown', { key: 'q' });
-        window.dispatchEvent(eventQ);
-    });
-    selectedSlot = await page.evaluate(() => window.selectedSlotIndex);
-    expect(selectedSlot).toBe(1); // Should still be 1
+        const selectedSlot = await page.evaluate(() => window.selectedSlotIndex);
+        expect(selectedSlot).toBe(i - 1);
+    }
 });
 
-test('UI labels for hand slots are 1 and 2', async ({ page }) => {
+test('UI labels for hand slots are 1 through 9', async ({ page }) => {
     test.setTimeout(60000);
     await page.goto('http://localhost:8080/index.htm');
     await page.click('#startButton');
     await page.waitForFunction(() => window.isWorldReady === true);
 
     const slotKeyBinds = await page.locator('.slot-key-bind').allTextContents();
-    expect(slotKeyBinds).toContain('1');
-    expect(slotKeyBinds).toContain('2');
-    expect(slotKeyBinds).not.toContain('Q');
-    expect(slotKeyBinds).not.toContain('E');
+    for (let i = 1; i <= 9; i++) {
+        expect(slotKeyBinds).toContain(i.toString());
+    }
+    expect(slotKeyBinds.length).toBe(9);
+});
+
+test('Empty hand slots do not show hand image', async ({ page }) => {
+    test.setTimeout(60000);
+    await page.goto('http://localhost:8080/index.htm');
+    await page.click('#startButton');
+    await page.waitForFunction(() => window.isWorldReady === true);
+
+    // Get all images in belt slots
+    const beltImagesCount = await page.locator('#inventoryBelt .slot .slot-icon').count();
+
+    // Since initially slots might be empty (except maybe some starting items, but belt usually starts empty or with one item)
+    // The key is that "empty" slots should NOT have an <img> with slot-icon class if they don't have an item.
+    // Actually, in my change, if there's no item, no img is created for 'belt' type.
+
+    const beltItems = await page.evaluate(() => window.beltItems);
+    let expectedImages = 0;
+    for (const item of beltItems) {
+        if (item) expectedImages++;
+    }
+
+    expect(beltImagesCount).toBe(expectedImages);
 });


### PR DESCRIPTION
I have increased the number of hand slots from 2 to 9 and removed the hand image that appeared in empty slots. 

Key changes:
- **Hotbar Expansion:** The player now has 9 slots in the belt/hotbar.
- **Dynamic Keybinds:** Slots are selectable using number keys 1 through 9.
- **Clean UI:** Empty slots no longer show a hand icon, providing a cleaner look.
- **Responsive Layout:** Adjusted the slot size to 60px and updated labels to ensure all 9 slots fit perfectly at the bottom of the screen.
- **Testing:** Updated the automated test suite to cover all 9 slots and verified visual appearance through Playwright.

---
*PR created automatically by Jules for task [3959328306504246593](https://jules.google.com/task/3959328306504246593) started by @Armandodecampos*