### PR TITLE
Increase hand slots to 9 and enhance inventory UI

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -217,7 +217,7 @@
             flex-direction: row; /* Alinha os itens horizontalmente */
             align-items: center; /* Centraliza itens verticalmente dentro da linha */
             gap: 8px; /* Espaço entre slots e botão */
-            background-color: rgba(0, 0, 0, 0.9); /* Fundo semi-transparente */
+            background-color: transparent; /* Fundo transparente */
             padding: 10px;
             border-radius: 10px;
             z-index: 998;
@@ -231,7 +231,7 @@
             height: 60px;
             border: 2px solid #555;
             border-radius: 50%;
-            background-color: rgba(255, 255, 255, 0.1);
+            background-color: transparent;
             display: flex;
             flex-direction: column; /* Para empilhar ícone e quantidade */
             justify-content: center;
@@ -4826,6 +4826,23 @@
                     isJumpBoosting = false; // Landed on walkable ground, stop boosting
                 }
             });
+
+            // NOVO: Seleção de slots com a roda do rato
+            window.addEventListener('wheel', (event) => {
+                if (!gamePaused && !backpackModal.classList.contains('active')) {
+                    if (event.deltaY > 0) {
+                        // Scroll para baixo: próximo slot
+                        stopDestruction();
+                        selectedSlotIndex = (selectedSlotIndex + 1) % numBeltSlots;
+                        updateBeltDisplay();
+                    } else if (event.deltaY < 0) {
+                        // Scroll para cima: slot anterior
+                        stopDestruction();
+                        selectedSlotIndex = (selectedSlotIndex - 1 + numBeltSlots) % numBeltSlots;
+                        updateBeltDisplay();
+                    }
+                }
+            }, { passive: true });
 
             // --- Configuração dos Cubos Interativos ---
             const cubeSize = 1;

--- a/tests/hand_slots.spec.js
+++ b/tests/hand_slots.spec.js
@@ -42,10 +42,6 @@ test('Empty hand slots do not show hand image', async ({ page }) => {
     // Get all images in belt slots
     const beltImagesCount = await page.locator('#inventoryBelt .slot .slot-icon').count();
 
-    // Since initially slots might be empty (except maybe some starting items, but belt usually starts empty or with one item)
-    // The key is that "empty" slots should NOT have an <img> with slot-icon class if they don't have an item.
-    // Actually, in my change, if there's no item, no img is created for 'belt' type.
-
     const beltItems = await page.evaluate(() => window.beltItems);
     let expectedImages = 0;
     for (const item of beltItems) {
@@ -53,4 +49,53 @@ test('Empty hand slots do not show hand image', async ({ page }) => {
     }
 
     expect(beltImagesCount).toBe(expectedImages);
+});
+
+test('Mouse wheel selection', async ({ page }) => {
+    test.setTimeout(60000);
+    await page.goto('http://localhost:8080/index.htm');
+    await page.click('#startButton');
+    await page.waitForFunction(() => window.isWorldReady === true);
+
+    // Initial slot should be 0
+    let selectedSlot = await page.evaluate(() => window.selectedSlotIndex);
+    expect(selectedSlot).toBe(0);
+
+    // Wheel down -> next slot (1)
+    await page.mouse.wheel(0, 100);
+    await page.waitForTimeout(100);
+    selectedSlot = await page.evaluate(() => window.selectedSlotIndex);
+    expect(selectedSlot).toBe(1);
+
+    // Wheel up -> previous slot (0)
+    await page.mouse.wheel(0, -100);
+    await page.waitForTimeout(100);
+    selectedSlot = await page.evaluate(() => window.selectedSlotIndex);
+    expect(selectedSlot).toBe(0);
+
+    // Wheel up again -> wrap to 8
+    await page.mouse.wheel(0, -100);
+    await page.waitForTimeout(100);
+    selectedSlot = await page.evaluate(() => window.selectedSlotIndex);
+    expect(selectedSlot).toBe(8);
+});
+
+test('Transparent background for belt and slots', async ({ page }) => {
+    test.setTimeout(60000);
+    await page.goto('http://localhost:8080/index.htm');
+    await page.click('#startButton');
+    await page.waitForFunction(() => window.isWorldReady === true);
+
+    const beltBg = await page.evaluate(() => {
+        const el = document.getElementById('inventoryBelt');
+        return window.getComputedStyle(el).backgroundColor;
+    });
+    // 'rgba(0, 0, 0, 0)' or 'transparent'
+    expect(beltBg === 'rgba(0, 0, 0, 0)' || beltBg === 'transparent').toBe(true);
+
+    const slotBg = await page.evaluate(() => {
+        const el = document.querySelector('.slot');
+        return window.getComputedStyle(el).backgroundColor;
+    });
+    expect(slotBg === 'rgba(0, 0, 0, 0)' || slotBg === 'transparent').toBe(true);
 });


### PR DESCRIPTION
- Expanded hand slots from 2 to 9 and updated UI/keybinds (1-9).
- Removed default hand icon for empty slots.
- Added mouse wheel support for slot selection.
- Set inventory belt and slot backgrounds to transparent.
- Updated Playwright tests and verified UI changes with screenshots.