### PR TITLE
Change collection key to 'F'

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -5189,7 +5189,7 @@
                     }
                 }
 
-                if (event.key.toLowerCase() === 'g') {
+                if (event.key.toLowerCase() === 'f') {
                     if (event.repeat) return;
                     collectObject();
                 }
@@ -7517,11 +7517,11 @@
                                 break;
                             }
                             if (body.userData.isRaft) {
-                                interactionHintText = "(E) Navegar / (G) Guardar";
+                                interactionHintText = "(E) Navegar / (F) Pegar";
                                 break;
                             }
                             if (body.userData.isCollectible) {
-                                interactionHintText = "(E) Pegar / (G) Guardar";
+                                interactionHintText = "(E) Segurar / (F) Pegar";
                                 break;
                             }
                             // Adiciona dicas contextuais para ferramentas

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
The collection key for objects (stones, crates, rafts) has been changed from 'G' to 'F' as requested. 

Changes:
- In the `keydown` event listener within `index.htm`, the 'g' key check was replaced with 'f' to call `collectObject()`.
- Interaction hints were updated globally:
    - For collectible items: `(E) Segurar / (F) Pegar` (previously `(E) Pegar / (G) Guardar`).
    - For rafts: `(E) Navegar / (F) Pegar` (previously `(E) Navegar / (G) Guardar`).
- Verified that 'F' successfully collects objects into the inventory and that the UI correctly displays the new keybinding.

---
*PR created automatically by Jules for task [8637529116825283509](https://jules.google.com/task/8637529116825283509) started by @Armandodecampos*