### PR TITLE
Make Caixote function as a chest with inventory support

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -853,12 +853,12 @@
     <div id="chestModal" class="hidden absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-stone-800/90 border-2 border-stone-600 rounded-lg p-4 pt-12 z-[1001] w-4/5 max-w-4xl max-h-[80%] flex flex-col text-white">
         <button id="closeChestButton" class="close-button">X</button>
         <div class="flex justify-between items-center mb-4">
-            <h2 class="text-2xl font-bold">Baú</h2>
+            <h2 class="text-2xl font-bold">Caixote</h2>
         </div>
         <div class="flex-grow grid grid-cols-2 gap-4 overflow-y-auto">
             <!-- Painel do Baú -->
             <div>
-                <h3 class="text-xl mb-2 text-center">Conteúdo do Baú</h3>
+                <h3 class="text-xl mb-2 text-center">Conteúdo do Caixote</h3>
                 <div id="chestSlotsContainer" class="flex flex-col gap-1 bg-black/30 p-2 rounded-md h-[calc(100%-2.5rem)] overflow-y-auto">
                     <!-- Slots do baú serão preenchidos dinamicamente -->
                 </div>
@@ -2291,7 +2291,9 @@
                 isCollectible: true,
                 type: boxItemName,
                 originalMass: initialCubeMass,
-                initialPosition: new CANNON.Vec3().copy(boxBody.position)
+                initialPosition: new CANNON.Vec3().copy(boxBody.position),
+                isChest: true, // NOVO: Caixotes agora funcionam como baús
+                inventory: new Array(numChestSlots).fill(null) // NOVO: Inventário do caixote
             };
 
             const mesh = new THREE.Mesh(cubeGeometry, cubeMaterialMesh);
@@ -2303,6 +2305,8 @@
             // Adiciona a nova caixa à lista de caixas colecionáveis
             collectibleBoxes.push({ body: boxBody, mesh: mesh });
             raycastTargetsNeedUpdate = true;
+
+            return boxBody;
         }
 
         // NOVO: Função genérica para dropar itens
@@ -5069,11 +5073,10 @@
 
             // O inventário do jogador agora começa vazio.
 
-            // Cria e preenche o baú inicial (Logo em frente ao jogador)
+            // Cria e preenche o caixote inicial (Logo em frente ao jogador)
             const startingChestHeight = getSurfaceHeight(0, -5);
-            const startingChestPosition = new THREE.Vector3(0, startingChestHeight + 0.5, -5); // 0.5 is half of chestSize (1)
-            createChest(startingChestPosition, null);
-            const startingChestBody = placedChests[placedChests.length - 1].body;
+            const startingChestPosition = new THREE.Vector3(0, startingChestHeight + 0.5, -5); // 0.5 is half of boxSize (1)
+            const startingChestBody = createBox(startingChestPosition, null);
             const startingChestInventory = startingChestBody.userData.inventory;
 
             addItemToInventory(startingChestInventory, { name: hammerItemName, quantity: 1 });
@@ -5879,6 +5882,15 @@
                     if (!clickedBody || !clickedBody.userData) continue;
 
                     if (!clickedBody.userData.isCollectible && !clickedBody.userData.isRaft) continue;
+
+                    // NOVO: Se for um contêiner (baú/caixote), só permite guardar se estiver vazio
+                    if (clickedBody.userData.isChest) {
+                        const inventory = clickedBody.userData.inventory;
+                        if (inventory && inventory.some(item => item !== null)) {
+                            // O contêiner não está vazio, não podemos guardá-lo
+                            continue;
+                        }
+                    }
 
                     const itemType = clickedBody.userData.type;
                     const itemQuantity = clickedBody.userData.quantity || 1; // Padrão para 1 se não especificado
@@ -8637,6 +8649,7 @@
             Object.defineProperty(window, 'playerHealth', { get: () => playerHealth, set: (v) => { playerHealth = v; } });
             Object.defineProperty(window, 'playerBreath', { get: () => playerBreath, set: (v) => { playerBreath = v; } });
             Object.defineProperty(window, 'isFainted', { get: () => isFainted, set: (v) => { isFainted = v; } });
+            Object.defineProperty(window, 'openedChest', { get: () => openedChest, set: (v) => { openedChest = v; } });
             Object.defineProperty(window, 'isJumpBoosting', { get: () => isJumpBoosting, set: (v) => { isJumpBoosting = v; } });
             window.faintPlayer = faintPlayer;
             window.respawnPlayer = respawnPlayer;
@@ -8679,6 +8692,7 @@
             window.waterMatrix = waterMatrix;
             window.THREE = THREE;
             window.addItemToInventory = addItemToInventory;
+            window.collectObject = collectObject;
             window.openChest = openChest;
             window.closeChest = closeChest;
             window.openBackpack = openBackpack;

--- a/tests/box_chest.spec.js
+++ b/tests/box_chest.spec.js
@@ -1,0 +1,108 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Box Chest Functionality', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('http://localhost:8080/index.htm');
+        await page.click('#startButton');
+        await page.waitForFunction(() => window.isWorldReady === true);
+    });
+
+    test('Starting object at (0,-5) is a box and has inventory', async ({ page }) => {
+        const starterInventory = await page.evaluate(() => {
+            // Find the object at (0, -5)
+            // We know it's the first box created in this case, or we can look for it
+            const starter = window.collectibleBoxes.find(b =>
+                Math.abs(b.body.position.x) < 1 && Math.abs(b.body.position.z + 5) < 1
+            );
+            if (!starter) return null;
+            return {
+                type: starter.body.userData.type,
+                isChest: starter.body.userData.isChest,
+                hasInventory: Array.isArray(starter.body.userData.inventory),
+                inventorySize: starter.body.userData.inventory ? starter.body.userData.inventory.length : 0,
+                contentCount: starter.body.userData.inventory ? starter.body.userData.inventory.filter(i => i !== null).length : 0
+            };
+        });
+
+        expect(starterInventory).not.toBeNull();
+        expect(starterInventory.type).toBe('caixote');
+        expect(starterInventory.isChest).toBe(true);
+        expect(starterInventory.hasInventory).toBe(true);
+        expect(starterInventory.inventorySize).toBe(50);
+        expect(starterInventory.contentCount).toBeGreaterThan(0);
+    });
+
+    test('Non-empty box cannot be collected', async ({ page }) => {
+        const collectionResult = await page.evaluate(async () => {
+            // Find the starter box
+            const starter = window.collectibleBoxes.find(b =>
+                Math.abs(b.body.position.x) < 1 && Math.abs(b.body.position.z + 5) < 1
+            );
+            if (!starter) return "not found";
+
+            // Move player to starter box
+            window.playerBody.position.set(0, starter.body.position.y + 2, -3);
+            window.playerBody.quaternion.setFromEuler(0, Math.PI, 0); // Look at -Z
+
+            const initialBackpackCount = window.backpackItems.filter(i => i !== null).length;
+
+            // Try to collect
+            window.collectObject();
+
+            const finalBackpackCount = window.backpackItems.filter(i => i !== null).length;
+            const stillInWorld = window.collectibleBoxes.includes(starter);
+
+            return {
+                initialBackpackCount,
+                finalBackpackCount,
+                stillInWorld
+            };
+        });
+
+        expect(collectionResult.finalBackpackCount).toBe(collectionResult.initialBackpackCount);
+        expect(collectionResult.stillInWorld).toBe(true);
+    });
+
+    test('Empty box can be collected', async ({ page }) => {
+        const collectionResult = await page.evaluate(async () => {
+            // Create a new empty box
+            const pos = new window.CANNON.Vec3(5, 5, 5);
+            const boxBody = window.createBox(pos, null);
+            const box = window.collectibleBoxes.find(b => b.body === boxBody);
+
+            // Move player to box
+            window.playerBody.position.set(5, 7, 3);
+            // Look at box
+            // For simplicity, we'll call collectObject directly while mocking the raycast result or just ensuring it's in range
+
+            // We need to ensure raycaster hits it.
+            // But we can also just test the logic inside collectObject by ensuring it's reached.
+            // Since we are in the browser context, we can just call the logic.
+
+            const initialBackpackCount = window.backpackItems.filter(i => i !== null).length;
+
+            // Mock raycaster hit for collectObject
+            const originalRaycast = window.raycaster.intersectObjects;
+            window.raycaster.intersectObjects = () => [{
+                distance: 1,
+                object: box.mesh
+            }];
+
+            window.collectObject();
+
+            window.raycaster.intersectObjects = originalRaycast; // restore
+
+            const finalBackpackCount = window.backpackItems.filter(i => i !== null).length;
+            const removedFromWorld = !window.collectibleBoxes.includes(box);
+
+            return {
+                initialBackpackCount,
+                finalBackpackCount,
+                removedFromWorld
+            };
+        });
+
+        expect(collectionResult.finalBackpackCount).toBe(collectionResult.initialBackpackCount + 1);
+        expect(collectionResult.removedFromWorld).toBe(true);
+    });
+});


### PR DESCRIPTION
This change transforms the 'Caixote' (box) entity into a fully functional container, equivalent to a chest ('Baú'). 

### Key Changes:
- **Logic Integration:** Updated `createBox` to include `isChest: true` and a 50-slot `inventory` in its physics body metadata.
- **Inventory Safety:** Modified `collectObject` to block the collection (picking up) of any container (box or chest) that is not empty, preventing accidental item loss.
- **Starting Equipment:** Replaced the legacy starting chest with a 'Caixote' at `(0, y, -5)` pre-filled with the starter kit.
- **UI Consistency:** Renamed the chest modal titles in `index.htm` to "Caixote" to match the visual object being interacted with.
- **Testing:** Added and passed automated tests (`tests/box_chest.spec.js`) and performed visual verification of interaction hints.
- **API Exposure:** Exposed `collectObject` and `openedChest` to `window` for improved testability.

---
*PR created automatically by Jules for task [13839525371567926223](https://jules.google.com/task/13839525371567926223) started by @Armandodecampos*