### PR TITLE
Fix sand mound building interaction

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -5739,7 +5739,7 @@
                     if (target.isDigging) {
                         const intersect = target.intersect;
                         const hitPoint = intersect.point;
-                        const isBuilding = (heldItemName === dirtItemName);
+                        const isBuilding = (heldItemName === dirtItemName || heldItemName === sandItemName);
 
                         // Alinha o ponto de impacto para busca precisa (agora com suporte a sub-grid)
                         const step = worldSize / (hfGridSize - 1);
@@ -5882,7 +5882,7 @@
                     const branchMultiplier = 4.0; // Bem lento
                     const weakMultiplier = 10.0;  // Muito mais lento (Mão) para incentivar o uso de ferramentas
 
-                    const isBuildingAction = (heldItemName === dirtItemName);
+                    const isBuildingAction = (heldItemName === dirtItemName || heldItemName === sandItemName);
 
                     // Define a ferramenta correta para cada material
                     const isCorrectTool = isBuildingAction ||
@@ -7937,7 +7937,7 @@
                                 basePosition.add(hitNormal.multiplyScalar(currentGhostHeight / 2));
 
                                 // NOVO: Alinhamento da grade
-                                if (currentBlockType === dirtItemName) {
+                                if (currentBlockType === dirtItemName || currentBlockType === sandItemName) {
                                     // Snapping para a grade do terreno (vértices)
                                     const step = worldSize / (hfGridSize - 1);
                                     const mx = Math.round((basePosition.x + visualOffsetX + worldSize / 2) / step);
@@ -7963,7 +7963,7 @@
                                 // NOVO: Alinha a posição Y na grade, considerando a altura da superfície da ilha como a base.
                                 // Isso garante que os blocos se encaixem verticalmente.
                                 // CORREÇÃO: As sementes não devem se encaixar na grade vertical, elas devem ser colocadas no chão.
-                                if (currentBlockType === 'muda_arvore' || currentBlockType === appleSeedItemName || currentBlockType === pineSeedItemName || currentBlockType === coconutItemName || currentBlockType === dirtItemName || currentBlockType === raftItemName) {
+                                if (currentBlockType === 'muda_arvore' || currentBlockType === appleSeedItemName || currentBlockType === pineSeedItemName || currentBlockType === coconutItemName || currentBlockType === dirtItemName || currentBlockType === sandItemName || currentBlockType === raftItemName) {
                                     placementPosition.y = basePosition.y;
                                 } else if (currentBlockType === boxItemName || currentBlockType === chestItemName) {
                                     placementPosition.y = basePosition.y;
@@ -8547,7 +8547,7 @@
                         crosshairColor = canDestroy ? (isTerraHit ? 'lime' : 'red') : 'white';
                     } else {
                         // Se estiver destruindo terra, usa lime (verde), se não usa red (vermelho)
-                        const isTerraCurrently = currentBlockType === dirtItemName;
+                        const isTerraCurrently = currentBlockType === dirtItemName || currentBlockType === sandItemName;
                         crosshairColor = isTerraCurrently ? 'lime' : 'red';
                     }
                 } else if (isPrimaryToolGrabbing) {


### PR DESCRIPTION
- Enabled `isBuilding` state when holding `sand`.
- Added `sand` to `isBuildingAction` for correct tool multiplier.
- Synchronized snapping and vertical alignment for `sand` mounds to match `dirt`.
- Updated crosshair color logic to correctly indicate building mode for `sand`.