### PR TITLE
Remove grass inside holes when digging

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -2302,6 +2302,12 @@
             // Adiciona o novo monte às listas e o retorna
             visualMounds.push(newMound);
             mounds.push(newMound);
+
+            // NOVO: Remove capim próximo se estiver cavando um buraco
+            if (!isPositive) {
+                removeCapimNear(newMound.position, 2.0);
+            }
+
             // updateIslandGeometry(newMound); // REMOVIDO: Não atualiza imediatamente ao cavar
             return newMound;
         }
@@ -2876,6 +2882,37 @@
             capimClusters.push(cluster);
         }
 
+        const zeroMatrix = new THREE.Matrix4().makeScale(0, 0, 0);
+        function removeCapimNear(position, radius) {
+            let removedCount = 0;
+            let anyRemoved = false;
+
+            for (let i = capimClusters.length - 1; i >= 0; i--) {
+                const cluster = capimClusters[i];
+                const dist = calculateWrappedDistance(position, cluster.position);
+
+                if (dist < radius) {
+                    // Esconde as instâncias no InstancedMesh
+                    for (let k = 0; k < bladesPerCluster; k++) {
+                        const instanceIdx = cluster.poolIndex * bladesPerCluster + k;
+                        capimInstancedMeshes[0].setMatrixAt(instanceIdx, zeroMatrix);
+                    }
+                    anyRemoved = true;
+
+                    // Retorna o índice para o pool
+                    capimFreeIndices.push(cluster.poolIndex);
+
+                    // Remove da lista
+                    capimClusters.splice(i, 1);
+                    removedCount++;
+                }
+            }
+            if (anyRemoved) {
+                capimInstancedMeshes[0].instanceMatrix.needsUpdate = true;
+            }
+            return removedCount;
+        }
+
         function isAreaOccupiedByConstruction(x, z, radius = 2.0) {
             const pos = new THREE.Vector3(x, 0, z);
 
@@ -2898,6 +2935,13 @@
             if (playerBody) {
                 const dist = calculateWrappedDistance(new THREE.Vector3(x, playerBody.position.y, z), playerBody.position);
                 if (dist < radius + playerRadius) return true;
+            }
+
+            // NOVO: Verifica se a área possui montes ou buracos
+            for (const mound of mounds) {
+                if (mound.flattened) continue;
+                const dist = calculateWrappedDistance(new THREE.Vector3(x, mound.position.y, z), mound.position);
+                if (dist < radius) return true;
             }
 
             return false;
@@ -6995,6 +7039,9 @@
                                 createDustCloud(mound.position, destroyTargetColor);
                                 mound.growthStage++;
 
+                                // NOVO: Remove capim próximo conforme o buraco cresce
+                                removeCapimNear(mound.position, 2.0);
+
                                 // Gain 1 terra/sand or 10 stones for each stage of digging
                                 const distFromCenter = Math.sqrt(mound.position.x ** 2 + mound.position.z ** 2);
                                 let itemToGive;
@@ -8992,10 +9039,12 @@
             Object.defineProperty(window, 'destroyProgress', { get: () => destroyProgress });
             Object.defineProperty(window, 'targetDestroyTime', { get: () => targetDestroyTime });
             window.capimClusters = capimClusters;
+            window.capimFreeIndices = capimFreeIndices;
             window.capimInstancedMeshes = capimInstancedMeshes;
             window.raycastTargets = raycastTargets;
             window.updateRaycastTargets = updateRaycastTargets;
             window.createMound = createMound;
+            window.removeCapimNear = removeCapimNear;
             window.mounds = mounds;
             window.islandMeshes = islandMeshes;
             window.visualMounds = visualMounds;

--- a/tests/grass_removal.spec.js
+++ b/tests/grass_removal.spec.js
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+test('Digging removes nearby grass', async ({ page }) => {
+  test.setTimeout(120000);
+  await page.goto('http://localhost:8080/index.htm');
+  await page.click('#startButton');
+
+  // Wait for world to be ready
+  await page.waitForFunction(() => window.isWorldReady === true, { timeout: 90000 });
+
+  // Place some grass at (10, surfaceHeight, 10) for testing if not already there
+  await page.evaluate(() => {
+    const pos = new window.THREE.Vector3(10, window.getSurfaceHeight(10, 10), 10);
+    // Force a capim cluster there if possible
+    if (window.capimFreeIndices.length > 0) {
+        // Clear any existing at that exact spot if any (unlikely)
+        window.removeCapimNear(pos, 5);
+        // Add one
+        const poolIndex = window.capimFreeIndices.pop();
+        const cluster = {
+            position: pos.clone(),
+            poolIndex: poolIndex,
+            count: 3
+        };
+        window.capimClusters.push(cluster);
+        // Update matrix to make it visible
+        const matrix = new window.THREE.Matrix4();
+        matrix.setPosition(pos);
+        window.capimInstancedMeshes[0].setMatrixAt(poolIndex * 6, matrix);
+        window.capimInstancedMeshes[0].instanceMatrix.needsUpdate = true;
+    }
+  });
+
+  // Verify grass exists near (10, 10)
+  let grassCountBefore = await page.evaluate(() => {
+    const pos = new window.THREE.Vector3(10, 0, 10);
+    return window.capimClusters.filter(c =>
+        window.calculateWrappedDistance(pos, c.position) < 2.0
+    ).length;
+  });
+  expect(grassCountBefore).toBeGreaterThan(0);
+
+  // Dig at (10, 10)
+  await page.evaluate(() => {
+    const intersect = {
+      point: new window.THREE.Vector3(10, window.getSurfaceHeight(10, 10), 10),
+      face: { normal: new window.THREE.Vector3(0, 1, 0) },
+      object: window.islandMeshes[4].mesh
+    };
+    window.createMound(intersect, false);
+  });
+
+  // Verify grass was removed
+  let grassCountAfter = await page.evaluate(() => {
+    const pos = new window.THREE.Vector3(10, 0, 10);
+    return window.capimClusters.filter(c =>
+        window.calculateWrappedDistance(pos, c.position) < 2.0
+    ).length;
+  });
+  expect(grassCountAfter).toBe(0);
+});


### PR DESCRIPTION
This change ensures that whenever a player digs a hole in the terrain, any grass clusters within the digging radius are removed. This is achieved by:
1. Identifying grass clusters near the digging site using toroidal distance calculations.
2. Hiding the visual instances in the `InstancedMesh` by setting their scale to zero.
3. Managing the internal state (`capimClusters` and `capimFreeIndices`) to reflect the removal and allow for pool reuse.
4. Preventing grass from respawning in areas occupied by mounds or holes by updating the occupancy check logic.

The implementation was verified using automated Playwright tests and visual recordings.

---
*PR created automatically by Jules for task [13664890578399920489](https://jules.google.com/task/13664890578399920489) started by @Armandodecampos*