### PR TITLE
Implement dynamic grass removal when digging holes

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -2305,7 +2305,9 @@
 
             // NOVO: Remove capim próximo se estiver cavando um buraco
             if (!isPositive) {
-                removeCapimNear(newMound.position, 2.0);
+                const worldStep = worldSize / hfGridSize;
+                const removalRadius = (newMound.radius + 0.5) * worldStep;
+                removeCapimNear(newMound.position, removalRadius);
             }
 
             // updateIslandGeometry(newMound); // REMOVIDO: Não atualiza imediatamente ao cavar
@@ -2941,7 +2943,9 @@
             for (const mound of mounds) {
                 if (mound.flattened) continue;
                 const dist = calculateWrappedDistance(new THREE.Vector3(x, mound.position.y, z), mound.position);
-                if (dist < radius) return true;
+                const worldStep = worldSize / hfGridSize;
+                const moundWorldRadius = (mound.radius + 0.5) * worldStep;
+                if (dist < moundWorldRadius) return true;
             }
 
             return false;
@@ -7040,7 +7044,9 @@
                                 mound.growthStage++;
 
                                 // NOVO: Remove capim próximo conforme o buraco cresce
-                                removeCapimNear(mound.position, 2.0);
+                                const worldStep = worldSize / hfGridSize;
+                                const removalRadius = (mound.radius + 0.5) * worldStep;
+                                removeCapimNear(mound.position, removalRadius);
 
                                 // Gain 1 terra/sand or 10 stones for each stage of digging
                                 const distFromCenter = Math.sqrt(mound.position.x ** 2 + mound.position.z ** 2);

--- a/tests/grass_removal.spec.js
+++ b/tests/grass_removal.spec.js
@@ -41,21 +41,23 @@ test('Digging removes nearby grass', async ({ page }) => {
   expect(grassCountBefore).toBeGreaterThan(0);
 
   // Dig at (10, 10)
-  await page.evaluate(() => {
+  const removalRadius = await page.evaluate(() => {
     const intersect = {
       point: new window.THREE.Vector3(10, window.getSurfaceHeight(10, 10), 10),
       face: { normal: new window.THREE.Vector3(0, 1, 0) },
       object: window.islandMeshes[4].mesh
     };
-    window.createMound(intersect, false);
+    const mound = window.createMound(intersect, false);
+    const worldStep = 1200 / 200; // worldSize / hfGridSize
+    return (mound.radius + 0.5) * worldStep;
   });
 
-  // Verify grass was removed
-  let grassCountAfter = await page.evaluate(() => {
+  // Verify grass was removed within the calculated radius
+  let grassCountAfter = await page.evaluate((radius) => {
     const pos = new window.THREE.Vector3(10, 0, 10);
     return window.capimClusters.filter(c =>
-        window.calculateWrappedDistance(pos, c.position) < 2.0
+        window.calculateWrappedDistance(pos, c.position) < radius
     ).length;
-  });
+  }, removalRadius);
   expect(grassCountAfter).toBe(0);
 });


### PR DESCRIPTION
- Added `removeCapimNear(position, radius)` to hide grass instances within a radius by scaling them to zero in the `InstancedMesh`.
- Integrated grass removal into `createMound` and the digging interaction loop (for hole growth).
- Updated the removal radius to match the visual terrain modification (`(mound.radius + 0.5) * worldStep`).
- Updated `isAreaOccupiedByConstruction` to include `mounds` with the same dynamic radius to prevent grass from respawning inside holes.
- Optimized performance by caching `zeroMatrix` and minimizing `instanceMatrix.needsUpdate` calls.
- Added and updated Playwright test `tests/grass_removal.spec.js` to verify the feature with the dynamic radius.