### PR TITLE
Allow grass growth on player-created dirt mounds

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -2910,7 +2910,7 @@
             return removedCount;
         }
 
-        function isAreaOccupiedByConstruction(x, z, radius = 2.0) {
+        function isAreaOccupiedByConstruction(x, z, radius = 2.0, allowDirtMounds = false) {
             const pos = new THREE.Vector3(x, 0, z);
 
             // Check placed constructions (blocks, floors, chests)
@@ -2937,6 +2937,9 @@
             // NOVO: Verifica se a área possui montes ou buracos
             for (const mound of mounds) {
                 if (mound.flattened) continue;
+                // Se permitirmos montes de terra (para crescimento de grama), ignoramos montes positivos de terra
+                if (allowDirtMounds && mound.itemType === dirtItemName && mound.maxHeightChange > 0) continue;
+
                 const dist = calculateWrappedDistance(new THREE.Vector3(x, mound.position.y, z), mound.position);
                 const worldStep = worldSize / hfGridSize;
                 const moundWorldRadius = (mound.radius + 0.5) * worldStep;
@@ -2961,14 +2964,29 @@
             const maxAttempts = Math.max(limit * 10, 20);
             while (capimClusters.length < targetCapimCount && spawnedCount < limit && totalAttempts < maxAttempts) {
                 totalAttempts++;
-                const angle = Math.random() * Math.PI * 2;
-                const dist = Math.random() * grassRadius;
-                const x = Math.cos(angle) * dist;
-                const z = Math.sin(angle) * dist;
-                const y = window.getSurfaceHeight(x, z);
+
+                let x, z, y;
+                // 30% de chance de tentar crescer grama em um monte de terra existente
+                const dirtMounds = mounds.filter(m => !m.flattened && m.itemType === dirtItemName && m.maxHeightChange > 0);
+                if (Math.random() < 0.3 && dirtMounds.length > 0) {
+                    const mound = dirtMounds[Math.floor(Math.random() * dirtMounds.length)];
+                    // Pequena variação aleatória ao redor do centro do monte
+                    const angle = Math.random() * Math.PI * 2;
+                    const r = Math.random() * (mound.radius * (worldSize / hfGridSize)) * 0.8;
+                    x = mound.position.x + Math.cos(angle) * r;
+                    z = mound.position.z + Math.sin(angle) * r;
+                    y = window.getActualHeight(x, z);
+                } else {
+                    const angle = Math.random() * Math.PI * 2;
+                    const dist = Math.random() * grassRadius;
+                    x = Math.cos(angle) * dist;
+                    z = Math.sin(angle) * dist;
+                    y = window.getActualHeight(x, z);
+                }
 
                 if (y > waterLevel + 0.5 && y < 25) {
-                    if (!isAreaOccupiedByConstruction(x, z, 2.0) && !isPositionOccupied(x, z, 4.0)) {
+                    // Permitimos crescer em montes de terra (allowDirtMounds = true)
+                    if (!isAreaOccupiedByConstruction(x, z, 2.0, true) && !isPositionOccupied(x, z, 4.0)) {
                         createCapim(new THREE.Vector3(x, y, z));
                         spawnedCount++;
                     }
@@ -3025,15 +3043,19 @@
             let attempts = 0;
             while (capimClusters.length < targetCapimCount && attempts < targetCapimCount * 5) {
                 attempts++;
+
+                let x, z, y;
+                // Em populateCapim (início do jogo), geralmente não há montes,
+                // mas usamos getActualHeight e allowDirtMounds para consistência total.
                 const angle = Math.random() * Math.PI * 2;
                 const dist = Math.random() * grassRadius;
-                const x = Math.cos(angle) * dist;
-                const z = Math.sin(angle) * dist;
-                const y = window.getSurfaceHeight(x, z);
+                x = Math.cos(angle) * dist;
+                z = Math.sin(angle) * dist;
+                y = window.getActualHeight(x, z);
 
                 // Coloca capim apenas se estiver acima do nível da água e na zona de terra
                 if (y > waterLevel + 0.5 && y < 25) {
-                    if (!isAreaOccupiedByConstruction(x, z, 2.0)) {
+                    if (!isAreaOccupiedByConstruction(x, z, 2.0, true)) {
                         createCapim(new THREE.Vector3(x, y, z));
                     }
                 }
@@ -4731,6 +4753,17 @@
                 return height + mountainHeight;
             }
             window.getSurfaceHeight = getSurfaceHeight;
+
+            // Função para pegar a altura real incluindo todos os montes de terra e areia ativos
+            window.getActualHeight = function(x, z) {
+                if (!window.currentHfMatrix) return window.getSurfaceHeight(x, z);
+                const step = worldSize / (hfGridSize - 1);
+                const mx = Math.round((x + worldSize / 2) / step);
+                const mz = Math.round((worldSize / 2 - z) / step);
+                const i = (mx % hfGridSize + hfGridSize) % hfGridSize;
+                const j = (mz % hfGridSize + hfGridSize) % hfGridSize;
+                return window.currentHfMatrix[i][j];
+            }
 
             const hfMatrix = [];
             for (let i = 0; i < hfGridSize; i++) { // i é o índice X local do Cannon

--- a/tests/grass_on_mounds.spec.js
+++ b/tests/grass_on_mounds.spec.js
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test';
+
+test('Grass can grow on dirt mounds', async ({ page }) => {
+  test.setTimeout(180000);
+  await page.goto('http://localhost:8080/index.htm');
+  await page.click('#startButton');
+
+  await page.waitForFunction(() => window.isWorldReady === true, { timeout: 30000 });
+
+  // 1. Create a dirt mound
+  await page.evaluate(async () => {
+    const { THREE, createMound, islandMeshes } = window;
+
+    // Explicitly using constants that might not be exposed on window
+    const dirtItemName = 'terra';
+    const moundGrowthStages = [0.25, 0.5, 0.75, 1.0];
+
+    // Simulate a hit on the terrain at (10, 0, 10)
+    const pos = new THREE.Vector3(10, 0, 10);
+    const intersect = {
+      point: pos,
+      face: { normal: new THREE.Vector3(0, 1, 0) },
+      object: islandMeshes[0].mesh
+    };
+
+    const mound = createMound(intersect, true, dirtItemName);
+    // Force the mound to complete immediately
+    mound.growthStage = moundGrowthStages.length;
+    mound.height = 1.0;
+    mound.lastDugAt = window.world.time;
+
+    window.updateIslandGeometry(mound);
+
+    // Set target capim count to a large number to trigger growth
+    window.targetCapimCount = window.capimClusters.length + 500;
+    // Set last growth time to far in the past to trigger immediately
+    window.lastGrassGrowthTime = -100;
+
+    console.log('Mound created at:', mound.position);
+  });
+
+  // 2. Poll for grass to grow
+  console.log('Waiting for grass growth...');
+
+  // Custom polling to trigger growth manually if needed (though the interval in code should handle it)
+  for (let i = 0; i < 20; i++) {
+     const found = await page.evaluate(() => {
+        const targetPos = { x: 10, z: 10 };
+        const radius = 3.0;
+        const islandSurfaceHeight = 0.8;
+
+        // Manually trigger growth check if time has passed
+        const now = window.world.time;
+        if (now - window.lastGrassGrowthTime >= 10) {
+            // Amount to spawn logic from code
+            const currentCount = window.capimClusters.length;
+            const targetCount = window.targetCapimCount;
+            if (currentCount < targetCount) {
+                window.respawnCapim(20);
+                window.lastGrassGrowthTime = now;
+            }
+        }
+
+        return window.capimClusters.some(cluster => {
+            const dx = cluster.position.x - targetPos.x;
+            const dz = cluster.position.z - targetPos.z;
+            const dist = Math.sqrt(dx*dx + dz*dz);
+            return dist < radius && cluster.position.y > islandSurfaceHeight + 0.1;
+        });
+     });
+
+     if (found) {
+        console.log('Grass on mound found!');
+        break;
+     }
+
+     // Advance time in evaluate
+     await page.evaluate(() => {
+        window.world.time += 1; // Advance 1 second
+     });
+     await new Promise(r => setTimeout(r, 1000));
+  }
+
+  const finalCheck = await page.evaluate(() => {
+    const targetPos = { x: 10, z: 10 };
+    const radius = 3.0;
+    const islandSurfaceHeight = 0.8;
+    return window.capimClusters.some(cluster => {
+        const dx = cluster.position.x - targetPos.x;
+        const dz = cluster.position.z - targetPos.z;
+        const dist = Math.sqrt(dx*dx + dz*dz);
+        return dist < radius && cluster.position.y > islandSurfaceHeight + 0.1;
+    });
+  });
+
+  expect(finalCheck).toBe(true);
+});


### PR DESCRIPTION
This change enables the natural growth of grass ("capim") on top of dirt mounds created by the player. Previously, grass only grew on the base terrain and was blocked by mounds.

Key changes:
- `isAreaOccupiedByConstruction`: Now accepts an optional `allowDirtMounds` parameter (default `false`) which prevents dirt mounds from being treated as obstacles for grass growth.
- `window.getActualHeight`: A new utility function that retrieves the current terrain elevation at specific coordinates by sampling the `currentHfMatrix` (physics heightfield), ensuring grass is placed at the correct height even on stacked mounds.
- `respawnCapim` & `populateCapim`: Updated to use `getActualHeight` for vertical positioning. `respawnCapim` now includes a 30% chance to specifically attempt spawning grass at the location of an existing dirt mound to make the feature more noticeable to players.
- Verification: Added `tests/grass_on_mounds.spec.js` and `/home/jules/verification/verify_grass_on_mounds.py` to ensure correctness and provide visual evidence.

---
*PR created automatically by Jules for task [7341041996151918859](https://jules.google.com/task/7341041996151918859) started by @Armandodecampos*