### PR TITLE
Add Rope and Fabric items to the game and starting crate

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1264,6 +1264,8 @@
         const shovelItemName = 'pá'; // NOVO: Nome do item de pá no inventário
         const pickaxeItemName = 'picareta'; // NOVO: Nome do item de picareta no inventário
         const branchItemName = 'galho'; // NOVO: Nome do item de galho no inventário
+        const ropeItemName = 'corda';
+        const fabricItemName = 'tecido';
 
         const stoneBlockItemName = 'bloco_pedra';
         const woodenBlockItemName = 'bloco_madeira';
@@ -1308,7 +1310,9 @@
             [branchItemName]: 'Galho',
             [stoneBlockItemName]: 'Bloco de Pedra',
             [woodenBlockItemName]: 'Bloco de Madeira',
-            [stoneFloorItemName]: 'Piso de Pedra'
+            [stoneFloorItemName]: 'Piso de Pedra',
+            [ropeItemName]: 'Corda',
+            [fabricItemName]: 'Tecido'
         };
 
         const itemWeights = {
@@ -1337,7 +1341,9 @@
             [branchItemName]: 0.5,
             [stoneBlockItemName]: 5.0,
             [woodenBlockItemName]: 3.0,
-            [stoneFloorItemName]: 2.0
+            [stoneFloorItemName]: 2.0,
+            [ropeItemName]: 0.5,
+            [fabricItemName]: 0.3
         };
 
         const maxWeight = 500; // Peso máximo que o jogador aguenta levar
@@ -1956,6 +1962,8 @@
             if (itemName === pineSeedItemName) return "https://placehold.co/100x100/8B4513/FFFFFF?text=Pinhão";
             if (itemName === coconutSeedItemName) return "https://placehold.co/100x100/D2B48C/FFFFFF?text=Semente+Coco";
             if (itemName === coconutItemName) return "https://placehold.co/100x100/F5F5DC/FFFFFF?text=Coco";
+            if (itemName === ropeItemName) return "https://placehold.co/100x100/8B4513/FFFFFF?text=Corda";
+            if (itemName === fabricItemName) return "https://placehold.co/100x100/FFFFFF/000000?text=Tecido";
             return handImageURL;
         }
         window.getItemIconURL = getItemIconURL;
@@ -5414,6 +5422,8 @@
             addItemToInventory(startingChestInventory, { name: woodenBlockItemName, quantity: 100 });
             addItemToInventory(startingChestInventory, { name: stoneFloorItemName, quantity: 100 });
             addItemToInventory(startingChestInventory, { name: axeItemName, quantity: 1 });
+            addItemToInventory(startingChestInventory, { name: ropeItemName, quantity: 10 });
+            addItemToInventory(startingChestInventory, { name: fabricItemName, quantity: 10 });
 
             // Pega o elemento do cinto de inventário e seus slots
             inventoryBeltElement = document.getElementById('inventoryBelt');


### PR DESCRIPTION
This change introduces two new items to the game: 'Corda' (Rope) and 'Tecido' (Fabric). 

Key changes:
1. **Item Definitions**: Added `ropeItemName` and `fabricItemName` constants in `index.htm`.
2. **Metadata**: Updated `itemDisplayNames` and `itemWeights` to include the new items (Rope: 0.5kg, Fabric: 0.3kg).
3. **Icons**: Updated `getItemIconURL` to provide dynamic placeholder icons using `placehold.co`.
4. **Initial Inventory**: Modified the `startGame` logic to ensure the starting crate (located at (0, -5)) is pre-populated with 10 units of Rope and 10 units of Fabric.

Verification:
- Created and ran a Playwright test (`tests/new_items.spec.js`) to confirm items exist in the crate and have correct metadata.
- Performed visual verification via a custom script (`verify_items.py`) and screenshots to confirm UI visibility.
- All existing tests passed.

---
*PR created automatically by Jules for task [16908152585264362727](https://jules.google.com/task/16908152585264362727) started by @Armandodecampos*