### PR TITLE
Fix invisible holes and ghost objects at map center

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -2309,6 +2309,7 @@
             };
 
             // Adiciona o novo monte às listas e o retorna
+            scene.add(holeGroup);
             visualMounds.push(newMound);
             mounds.push(newMound);
 
@@ -2635,7 +2636,7 @@
                 targetZ = forcedZ;
             } else {
                 const angle = Math.random() * Math.PI * 2;
-                const dist = Math.random() * (worldSize / 2);
+                const dist = 5 + Math.random() * (worldSize / 2 - 5);
                 targetX = Math.cos(angle) * dist;
                 targetZ = Math.sin(angle) * dist;
             }
@@ -3009,7 +3010,7 @@
             while (currentStoneCount < targetStoneCount && totalAttempts < 20) {
                 totalAttempts++;
                 const angle = Math.random() * Math.PI * 2;
-                const dist = Math.random() * capimRadius * 2; // Stones can be on beach too
+                const dist = 5 + Math.random() * (capimRadius * 2 - 5); // Stones can be on beach too
                 const x = Math.cos(angle) * dist;
                 const z = Math.sin(angle) * dist;
                 const y = window.getSurfaceHeight(x, z);
@@ -3033,7 +3034,7 @@
 
                 attempts++;
                 const angle = Math.random() * Math.PI * 2;
-                const dist = Math.random() * (worldSize / 2); // Scattered across whole world
+                const dist = 5 + Math.random() * (worldSize / 2 - 5); // Scattered across whole world
                 const x = Math.cos(angle) * dist;
                 const z = Math.sin(angle) * dist;
                 const y = window.getSurfaceHeight(x, z);


### PR DESCRIPTION
This change fixes a bug where digging holes in the terrain was visually "invisible" and sometimes revealed interactable "ghost" objects at the center of the map.

The investigation revealed that:
1. The `createMound` function was missing the code to add the hole's visual mesh to the 3D scene.
2. Resource spawning logic for stones and meteors lacked a safety offset, allowing them to spawn exactly at (0,0,0), which is where the player often digs first or where default coordinates might point.

Fixes applied:
- Explicitly added the hole's visual representation to the scene.
- Added a 5-unit exclusion radius around the map center for all stone and meteor spawning events.

---
*PR created automatically by Jules for task [8554195509151510683](https://jules.google.com/task/8554195509151510683) started by @Armandodecampos*