### PR TITLE
Add campfire (fogueira) item with ghost preview and placement.

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -6388,6 +6388,7 @@
                     else if (currentBlockType === boxItemName && cubeMaterialMesh) materialLoaded = true;
                     else if (currentBlockType === raftItemName && raftMaterialMesh) materialLoaded = true; // NOVO
                     else if (currentBlockType === stoneItemName) materialLoaded = true; // Pedra sempre carregada (usa material básico)
+                    else if (currentBlockType === campfireItemName) materialLoaded = true;
 
                     if (materialLoaded) {
                         if (currentBlockType === boxItemName) {
@@ -6396,6 +6397,8 @@
                             createRaft(ghostBlockMesh.position, ghostBlockMesh.quaternion);
                         } else if (currentBlockType === stoneItemName) {
                             createStone(ghostBlockMesh.position, ghostBlockMesh.quaternion);
+                        } else if (currentBlockType === campfireItemName) {
+                            createPlaceableBlock(ghostBlockMesh.position, ghostBlockMesh.quaternion, campfireItemName);
                         }
                         else {
                             createPlaceableBlock(ghostBlockMesh.position, ghostBlockMesh.quaternion, currentBlockType);
@@ -8240,6 +8243,25 @@
                         } else if (currentBlockType === stoneItemName) {
                             ghostBlockMesh.geometry = new THREE.DodecahedronGeometry(0.25, 0);
                             ghostBlockMesh.scale.set(1.2, 0.6, 1.4);
+                        } else if (currentBlockType === campfireItemName) {
+                            ghostBlockMesh.geometry = new THREE.BoxGeometry(0, 0, 0);
+                            const campfireGroup = new THREE.Group();
+                            const logMat = ghostBlockMaterial;
+                            for (let i = 0; i < 6; i++) {
+                                const log = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.05, 0.6, 8), logMat);
+                                log.rotation.z = Math.PI / 2;
+                                log.rotation.y = (i / 6) * Math.PI * 2;
+                                log.position.y = -0.15;
+                                campfireGroup.add(log);
+                            }
+                            const fireMat = new THREE.MeshStandardMaterial({ color: 0xff4500, transparent: true, opacity: 0.4 });
+                            for (let i = 0; i < 4; i++) {
+                                const fire = new THREE.Mesh(new THREE.ConeGeometry(0.15, 0.4, 8), fireMat);
+                                fire.position.set((Math.random()-0.5)*0.2, 0.1, (Math.random()-0.5)*0.2);
+                                fire.rotation.y = Math.random() * Math.PI;
+                                campfireGroup.add(fire);
+                            }
+                            ghostBlockMesh.add(campfireGroup);
                         }
                     }
 
@@ -8255,6 +8277,7 @@
                     else if (currentBlockType === 'tronco_arvore') currentGhostHeight = trunkHeight;
                     else if (currentBlockType === boxItemName) currentGhostHeight = 1;
                     else if (currentBlockType === stoneItemName) currentGhostHeight = 0.5;
+                    else if (currentBlockType === campfireItemName) currentGhostHeight = 0.5;
                     // Update ghost block geometry
                     // ghostBlockMesh.geometry = new THREE.BoxGeometry(currentGhostWidth, currentGhostHeight, currentGhostDepth); // Removido para lidar individualmente
 


### PR DESCRIPTION
- Implemented campfire visual model and animated fire with lighting.
- Added ghost preview for campfire when selected in inventory.
- Enabled placement of campfire via mouse click on the ground.
- Restricted interaction: campfires cannot be grabbed or stored, only destroyed.
- Destruction yields 2 branches (galhos).
- Added campfire to starting crates.