### PR TITLE
Smoother and Slower Campfire Glow

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -7018,13 +7018,13 @@
                 activeCampfires.forEach(cf => {
                     if (cf.userData.fireGroup) {
                         cf.userData.fireGroup.children.forEach((fire, i) => {
-                            fire.scale.y = 0.8 + Math.sin(now * 0.01 + i) * 0.3;
-                            fire.scale.x = fire.scale.z = 0.9 + Math.cos(now * 0.015 + i) * 0.1;
+                            fire.scale.y = 0.8 + Math.sin(now * 0.003 + i) * 0.3;
+                            fire.scale.x = fire.scale.z = 0.9 + Math.cos(now * 0.004 + i) * 0.1;
                             fire.rotation.y += 0.02 * delta;
                         });
                     }
                     if (cf.userData.fireLight) {
-                        cf.userData.fireLight.intensity = 1.2 + Math.sin(now * 0.02) * 0.3;
+                        cf.userData.fireLight.intensity = 1.2 + Math.sin(now * 0.005) * 0.1;
                     }
                 });
             }


### PR DESCRIPTION
Adjusted the campfire's flickering and flame animation in `index.htm` to be slower and smoother. The light intensity oscillation frequency was reduced from 0.02 to 0.005, and its amplitude from 0.3 to 0.1. The flame scaling frequency was also slowed down (from 0.01/0.015 to 0.003/0.004). Verified visually with Playwright.

---
*PR created automatically by Jules for task [2777511684669266397](https://jules.google.com/task/2777511684669266397) started by @Armandodecampos*