### PR TITLE
Adjust campfire and torch visuals

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -3945,19 +3945,19 @@
             // Outer flames (Gota shape) - Reduced scale for realism
             for (let i = 0; i < 3; i++) {
                 const fire = new THREE.Mesh(torchFireGeom, torchOrangeFireMat);
-                // Reduced scale: bundleRadius*1.5 for width, bundleHeight*1.0 for height
-                const sW = bundleRadius * 1.5;
-                const sH = bundleHeight * 1.0;
+                // Increased scale for visibility
+                const sW = bundleRadius * 3.0;
+                const sH = bundleHeight * 2.0;
                 fire.scale.set(sW, sH, sW);
                 fire.userData.baseScale = { x: sW, y: sH, z: sW };
                 fire.position.set((Math.random() - 0.5) * 0.05, bundleHeight * 0.1, (Math.random() - 0.5) * 0.05);
                 fire.rotation.y = Math.random() * Math.PI;
                 fireGroup.add(fire);
             }
-            // Inner flame (Gota shape) - Reduced scale
+            // Inner flame (Gota shape) - Increased scale
             const innerFire = new THREE.Mesh(torchFireGeom, torchYellowFireMat);
-            const siW = bundleRadius * 0.9;
-            const siH = bundleHeight * 0.8;
+            const siW = bundleRadius * 1.8;
+            const siH = bundleHeight * 1.6;
             innerFire.scale.set(siW, siH, siW);
             innerFire.userData.baseScale = { x: siW, y: siH, z: siW };
             innerFire.position.y = bundleHeight * 0.1;
@@ -4115,7 +4115,7 @@
                     const sW = 0.35; const sH = 0.5;
                     fire.scale.set(sW, sH, sW); // Proportional scale for campfire
                     fire.userData.baseScale = { x: sW, y: sH, z: sW };
-                    fire.position.set((Math.random()-0.5)*0.2, 0.1, (Math.random()-0.5)*0.2);
+                    fire.position.set((Math.random()-0.5)*0.2, -0.05, (Math.random()-0.5)*0.2);
                     fire.rotation.y = Math.random() * Math.PI;
                     fireGroup.add(fire);
                 }
@@ -4124,7 +4124,7 @@
                 const siW = 0.2; const siH = 0.4;
                 innerFire.scale.set(siW, siH, siW);
                 innerFire.userData.baseScale = { x: siW, y: siH, z: siW };
-                innerFire.position.y = 0.1;
+                innerFire.position.y = -0.05;
                 innerFire.userData.isInnerFlame = true;
                 fireGroup.add(innerFire);
 
@@ -4611,7 +4611,7 @@
             // Inclina a tocha para frente
             heldTorchModel.group.rotation.x = -Math.PI / 4;
 
-            heldTorchGroup.position.set(0.3, -0.25, -0.4); // Posiciona no canto inferior direito da tela
+            heldTorchGroup.position.set(0.4, -0.4, -0.8); // Posiciona no canto inferior direito da tela, mais para trás
             heldTorchGroup.visible = false;
             camera.add(heldTorchGroup);
 
@@ -8477,7 +8477,7 @@
                             });
                             for (let i = 0; i < 4; i++) {
                                 const fire = new THREE.Mesh(new THREE.ConeGeometry(0.15, 0.4, 8), fireMat);
-                                fire.position.set((Math.random()-0.5)*0.2, 0.1, (Math.random()-0.5)*0.2);
+                                fire.position.set((Math.random()-0.5)*0.2, -0.05, (Math.random()-0.5)*0.2);
                                 fire.rotation.y = Math.random() * Math.PI;
                                 campfireGroup.add(fire);
                             }
@@ -8496,7 +8496,7 @@
                                 emissiveIntensity: 1.5
                             });
                             for (let i = 0; i < 3; i++) {
-                                const fire = new THREE.Mesh(new THREE.ConeGeometry(0.08, 0.25, 8), fireMat);
+                                const fire = new THREE.Mesh(new THREE.ConeGeometry(0.16, 0.5, 8), fireMat);
                                 fire.position.set((Math.random() - 0.5) * 0.1, 0.9, (Math.random() - 0.5) * 0.1); // Gap acima do topo (0.8)
                                 fire.rotation.y = Math.random() * Math.PI;
                                 torchGroup.add(fire);


### PR DESCRIPTION
This PR addresses three visual adjustments requested for the campfire and torch items:
1.  **Campfire Alignment:** The campfire flames (both inner and outer) have been lowered by 0.15 units (from Y=0.1 to Y=-0.05) to ensure they are properly seated on the log base.
2.  **Torch Flame Scaling:** The torch flames have been doubled in size. Specifically, the outer flame scale was increased from (1.5, 1.0) to (3.0, 2.0) relative to the bundle radius/height, and the inner flame was similarly adjusted. The `torchFireGeom` (used for the ghost/preview) also had its dimensions doubled from (0.08, 0.25) to (0.16, 0.5).
3.  **Held Torch Perspective:** The held torch model's position was moved from `(0.3, -0.25, -0.4)` to `(0.4, -0.4, -0.8)` relative to the camera, effectively pushing it further back, down, and to the right to minimize its visibility and hide the "tip" (flame end) from the player's direct line of sight.

Verified functional correctness with Playwright tests and confirmed visual changes via manual screenshot checks.

---
*PR created automatically by Jules for task [9860198617284484019](https://jules.google.com/task/9860198617284484019) started by @Armandodecampos*