### PR TITLE
Make rain intensity constant until it stops

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -3514,28 +3514,16 @@
                         startRainCycle();
                     }
                 } else {
-                    // Se já estiver chovendo, chance de parar ou mudar de intensidade significativamente
+                    // Se já estiver chovendo, só tem a chance de parar.
+                    // Removido a mudança de intensidade no meio do ciclo para atender pedido do usuário.
                     if (Math.random() < 0.4) {
                         targetRainIntensity = 0;
                         rainCloud.active = false;
-                    } else {
-                        // Mantém a chuva mas pode mudar o alvo da nuvem atual
-                        rainCloud.targetIntensity = 0.1 + Math.random() * 0.9;
-                        targetRainIntensity = rainCloud.targetIntensity;
                     }
                 }
 
                 // Atualiza a quantidade base de nuvens de forma aleatória a cada mudança de ciclo
                 randomBaseCloudCount = Math.floor(Math.random() * 30);
-            }
-
-            // Oscilação aleatória constante durante a chuva para torná-la dinâmica
-            if (targetRainIntensity > 0 && rainCloud.active) {
-                if (Math.random() < 0.005) {
-                    const fluctuation = (Math.random() - 0.5) * 0.3;
-                    rainCloud.targetIntensity = Math.max(0.1, Math.min(1.0, rainCloud.targetIntensity + fluctuation));
-                    targetRainIntensity = rainCloud.targetIntensity;
-                }
             }
 
             // Se não estiver chovendo, a quantidade de nuvens é a base aleatória.

--- a/tests/weather_persistence.spec.js
+++ b/tests/weather_persistence.spec.js
@@ -1,0 +1,60 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Weather Persistence', () => {
+    test.beforeEach(async ({ page }) => {
+        test.setTimeout(120000);
+        await page.goto('http://localhost:8080/index.htm');
+        await page.click('#startButton');
+        await page.waitForFunction(() => window.isWorldReady === true, { timeout: 90000 });
+        await page.evaluate(() => { window.gamePaused = false; });
+    });
+
+    test('targetRainIntensity remains constant during a rain cycle', async ({ page }) => {
+        const result = await page.evaluate(() => {
+            window.startRainCycle();
+            const initialTargetIntensity = window.targetRainIntensity;
+            let stayedConstant = true;
+
+            // Simula 100 frames
+            for (let i = 0; i < 100; i++) {
+                window.updateWeather(0.016);
+                if (window.targetRainIntensity !== initialTargetIntensity) {
+                    stayedConstant = false;
+                    break;
+                }
+            }
+            return { initialTargetIntensity, stayedConstant };
+        });
+
+        expect(result.initialTargetIntensity).toBeGreaterThan(0);
+        expect(result.stayedConstant).toBe(true);
+    });
+
+    test('targetRainIntensity does not change when world.time advances if it is not yet time to change', async ({ page }) => {
+        const result = await page.evaluate(() => {
+            window.startRainCycle();
+            // Sincroniza world.time e lastWeatherChange
+            window.world.time = 1000;
+            window.lastWeatherChange = 1000;
+            // Define uma duração longa para o ciclo de chuva para não mudar durante o teste
+            window.nextWeatherDuration = 200;
+
+            const initialTargetIntensity = window.targetRainIntensity;
+            let stayedConstant = true;
+
+            // Simula 50s de tempo de jogo (abaixo dos 200s definidos)
+            for (let i = 0; i < 500; i++) {
+                window.world.time += 0.1;
+                window.updateWeather(0.016);
+                if (window.targetRainIntensity !== initialTargetIntensity) {
+                    stayedConstant = false;
+                    break;
+                }
+            }
+            return { initialTargetIntensity, stayedConstant };
+        });
+
+        expect(result.initialTargetIntensity).toBeGreaterThan(0);
+        expect(result.stayedConstant).toBe(true);
+    });
+});


### PR DESCRIPTION
The rain intensity in the game was fluctuating frequently due to random updates mid-cycle and frame-by-frame noise. I modified `index.htm` to remove these fluctuations, ensuring rain remains constant from start to finish of a cycle. I also added a new Playwright test suite to verify that `targetRainIntensity` stays stable over time during a rain event.

---
*PR created automatically by Jules for task [14363915080818568851](https://jules.google.com/task/14363915080818568851) started by @Armandodecampos*