### PR TITLE
Double ground healing time for holes

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -8154,8 +8154,8 @@
             // NOVO: Lógica para fechar buracos inativos (curar terreno após 10 segundos)
             for (let i = visualMounds.length - 1; i >= 0; i--) {
                 const mound = visualMounds[i];
-                // Cura apenas buracos reais abaixo do nível natural (isHole) após 30 segundos de inatividade
-                if (mound !== currentMound && mound.isHole && world.time - mound.lastDugAt > 30) {
+                // Cura apenas buracos reais abaixo do nível natural (isHole) após 60 segundos de inatividade
+                if (mound !== currentMound && mound.isHole && world.time - mound.lastDugAt > 60) {
                     mound.closingStartTime = undefined;
                     closingMounds.push(mound);
                     visualMounds.splice(i, 1);
@@ -8171,7 +8171,7 @@
                     mound.startHeight = mound.height;
                 }
 
-                const duration = 5.0; // 5 segundos para curar suavemente
+                const duration = 10.0; // 10 segundos para curar suavemente
                 const elapsed = world.time - mound.closingStartTime;
                 const progress = Math.min(1.0, elapsed / duration);
 


### PR DESCRIPTION
I have doubled the time it takes for holes in the ground to heal. Specifically, I modified `index.htm` to:
1. Increase the inactivity threshold before a hole starts healing from 30 seconds to 60 seconds.
2. Increase the duration of the visual healing process (smooth terrain recovery) from 5 seconds to 10 seconds.

These changes ensure that player-dug holes persist for twice as long and heal more gradually. Verified the logic with automated tests and manual code inspection.

---
*PR created automatically by Jules for task [14781728753606337010](https://jules.google.com/task/14781728753606337010) started by @Armandodecampos*