### PR TITLE
Add Cesto de Capim (Grass Basket) item

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1311,6 +1311,7 @@
         let chestSlotsContainer;
         let chestBackpackSlotsContainer;
         const numChestSlots = 50;
+        const numBasketSlots = 17; // NOVO: 1/3 da capacidade do caixote (aprox)
         let openedChest = null; // Guarda a referência para os dados do contêiner aberto
 
         // Inventário (agora separado para cinto e mochila)
@@ -1365,6 +1366,7 @@
         const treeTrunkItemName = 'tronco_arvore'; // NOVO: Nome do item de tronco de árvore
         const woodenPlankItemName = 'tábuas'; // NOVO: Nome do item de tábuas de madeira
         const boxItemName = 'caixote'; // NOVO: Nome do item de caixote
+        const basketItemName = 'cesto_capim'; // NOVO: Nome do item de cesto de capim
 
         // NOVO: Mapeamento de nomes de itens para exibição
         window.itemDisplayNames = {
@@ -1397,7 +1399,8 @@
             [ropeItemName]: 'Corda',
             [fabricItemName]: 'Tecido',
             [campfireItemName]: 'Fogueira\nProporciona luz e calor',
-            [torchItemName]: 'Tocha\nIlumina o caminho'
+            [torchItemName]: 'Tocha\nIlumina o caminho',
+            [basketItemName]: 'Cesto de Capim'
         };
 
         const itemWeights = {
@@ -1422,6 +1425,7 @@
             [treeTrunkItemName]: 12.0,
             [woodenPlankItemName]: 1.5,
             [boxItemName]: 12.0,
+            [basketItemName]: 4.0, // NOVO: 1/3 do peso do caixote
             [raftItemName]: 30.0, // Jangada é pesada
             [branchItemName]: 0.5,
             [stoneBlockItemName]: 5.0,
@@ -1531,6 +1535,7 @@
 
         // Global variables for materials
         let cubeMaterialMesh; // NOVO: Material da caixa global
+        let basketMaterialMesh; // NOVO: Material do cesto global
         let raftMaterialMesh; // NOVO: Material da jangada
         let sailMaterialMesh; // NOVO: Material da vela da jangada
         let raftLogGeometry, raftSupportGeometry, raftMastGeometry, raftYardarmGeometry, raftSailGeometry, raftRopeGeometry;
@@ -1708,6 +1713,7 @@
             window.useTextures = useTextures;
             // Update materials
             if (cubeMaterialMesh) cubeMaterialMesh.map = useTextures ? (texturesRegistry.cube || null) : null;
+            if (basketMaterialMesh) basketMaterialMesh.map = useTextures ? (texturesRegistry.capim || null) : null;
             if (cobMaterialMesh) cobMaterialMesh.map = useTextures ? (texturesRegistry.cob || null) : null;
             if (floorMaterialMesh) floorMaterialMesh.map = useTextures ? (texturesRegistry.floor || null) : null;
             if (woodenPlankMaterialMesh) woodenPlankMaterialMesh.map = useTextures ? (texturesRegistry.plank || null) : null;
@@ -1723,7 +1729,7 @@
             if (stoneHoleMaterial) stoneHoleMaterial.map = useTextures ? (texturesRegistry.stone || null) : null;
 
             // Notify materials of changes
-            [cubeMaterialMesh, cobMaterialMesh, floorMaterialMesh, woodenPlankMaterialMesh,
+            [cubeMaterialMesh, basketMaterialMesh, cobMaterialMesh, floorMaterialMesh, woodenPlankMaterialMesh,
              stoneBlockMaterialMesh, woodenBlockMaterialMesh, stoneFloorMaterialMesh,
              raftMaterialMesh, sailMaterialMesh, treeTrunkMaterialMesh, treeLeavesMaterialMesh,
              treeSaplingMaterialMesh, holeMaterial, stoneHoleMaterial].forEach(m => {
@@ -2064,6 +2070,7 @@
             if (itemName === woodenBlockItemName) return woodenBlockTextureURL;
             if (itemName === stoneFloorItemName) return stoneFloorTextureURL;
             if (itemName === boxItemName) return cubeTextureURL;
+            if (itemName === basketItemName) return 'https://placehold.co/100x100/2d5a27/FFFFFF?text=Cesto';
             if (itemName === appleItemName) return "https://placehold.co/100x100/ff0000/FFFFFF?text=Maçã"; // Adicionado na etapa 3
             if (itemName === pineSeedItemName) return "https://placehold.co/100x100/8B4513/FFFFFF?text=Pinhão";
             if (itemName === coconutSeedItemName) return "https://placehold.co/100x100/D2B48C/FFFFFF?text=Semente+Coco";
@@ -2281,7 +2288,7 @@
             // Conteúdo do Contêiner
             chestSlotsContainer.innerHTML = '';
             const chestInventory = openedChest.userData.inventory;
-            for (let i = 0; i < numChestSlots; i++) {
+            for (let i = 0; i < chestInventory.length; i++) {
                 const item = chestInventory[i];
                 const slotDiv = renderSlot(item, i, 'chest'); // Novo tipo de contêiner
                 chestSlotsContainer.appendChild(slotDiv);
@@ -2469,6 +2476,49 @@
             raycastTargetsNeedUpdate = true;
 
             return boxBody;
+        }
+
+        // NOVO: Função para criar um novo cesto dinâmico
+        function createBasket(position, quaternion) {
+            const basketSize = 0.5; // Dobro menor que o caixote (1.0)
+            const initialBasketMass = 10; // Mais leve que o caixote
+            const basketShape = new CANNON.Box(new CANNON.Vec3(basketSize / 2, basketSize / 2, basketSize / 2));
+            const basketGeometry = new THREE.BoxGeometry(basketSize, basketSize, basketSize);
+
+            const basketBody = new CANNON.Body({
+                mass: initialBasketMass,
+                shape: basketShape,
+                material: cubeMaterial,
+                linearDamping: 0.3,
+                angularDamping: 0.3,
+                allowSleep: true,
+                sleepSpeedLimit: 0.01,
+                sleepTimeLimit: 1.0
+            });
+            basketBody.position.copy(position);
+            if (quaternion) {
+                basketBody.quaternion.copy(quaternion);
+            }
+            world.addBody(basketBody);
+            basketBody.userData = {
+                isCollectible: true,
+                type: basketItemName,
+                originalMass: initialBasketMass,
+                initialPosition: new CANNON.Vec3().copy(basketBody.position),
+                isChest: true,
+                inventory: new Array(numBasketSlots).fill(null)
+            };
+
+            const mesh = new THREE.Mesh(basketGeometry, basketMaterialMesh);
+            mesh.castShadow = true;
+            mesh.receiveShadow = true;
+            mesh.userData.physicsBody = basketBody;
+            scene.add(mesh);
+
+            collectibleBoxes.push({ body: basketBody, mesh: mesh });
+            raycastTargetsNeedUpdate = true;
+
+            return basketBody;
         }
 
         // NOVO: Função genérica para dropar itens
@@ -4639,6 +4689,7 @@
 
             // Inicializa materiais com padrões para evitar erros de undefined e falta de textura inicial
             cubeMaterialMesh = new THREE.MeshStandardMaterial({ color: 0xcccccc });
+            basketMaterialMesh = new THREE.MeshStandardMaterial({ color: 0x32CD32 }); // Cor inicial verde (LimeGreen)
             raftMaterialMesh = new THREE.MeshStandardMaterial({ color: 0x8B4513 });
             sailMaterialMesh = new THREE.MeshStandardMaterial({ color: 0xF5F5DC, side: THREE.DoubleSide });
             cobMaterialMesh = new THREE.MeshStandardMaterial({ color: 0x8B4513 });
@@ -5669,6 +5720,7 @@
             addItemToInventory(startingChestInventory, { name: fabricItemName, quantity: 10 });
             addItemToInventory(startingChestInventory, { name: campfireItemName, quantity: 5 });
             addItemToInventory(startingChestInventory, { name: torchItemName, quantity: 10 });
+            addItemToInventory(startingChestInventory, { name: basketItemName, quantity: 5 });
 
             // Pega o elemento do cinto de inventário e seus slots
             inventoryBeltElement = document.getElementById('inventoryBelt');
@@ -6064,7 +6116,7 @@
                 // O martelo foi removido temporariamente das ferramentas de destruição
                 if (item.name === axeItemName || item.name === pickaxeItemName || item.name === shovelItemName || item.name === branchItemName || item.name === dirtItemName || item.name === sandItemName) return 'destroy';
                 // Itens de colocação
-                if (item.name === cobItemName || item.name === floorItemName || item.name === treeSaplingItemName || item.name === appleSeedItemName || item.name === pineSeedItemName || item.name === coconutItemName || item.name === woodenPlankItemName || item.name === treeTrunkItemName || item.name === boxItemName || item.name === raftItemName || item.name === stoneBlockItemName || item.name === woodenBlockItemName || item.name === stoneFloorItemName || item.name === stoneItemName || item.name === campfireItemName || item.name === torchItemName) return 'place';
+                if (item.name === cobItemName || item.name === floorItemName || item.name === treeSaplingItemName || item.name === appleSeedItemName || item.name === pineSeedItemName || item.name === coconutItemName || item.name === woodenPlankItemName || item.name === treeTrunkItemName || item.name === boxItemName || item.name === basketItemName || item.name === raftItemName || item.name === stoneBlockItemName || item.name === woodenBlockItemName || item.name === stoneFloorItemName || item.name === stoneItemName || item.name === campfireItemName || item.name === torchItemName) return 'place';
                 return null; // Retorna nulo se o item não tiver um tipo de ação conhecido
             }
 
@@ -6288,7 +6340,7 @@
                         baseDurability = target.body.userData.durability || 1.0;
                         const targetType = target.body.userData.type;
                         const isTree = !!target.body.userData.growthStage;
-                        const isWooden = [woodenPlankItemName, treeTrunkItemName, boxItemName, woodenBlockItemName].includes(targetType);
+                        const isWooden = [woodenPlankItemName, treeTrunkItemName, boxItemName, basketItemName, woodenBlockItemName].includes(targetType);
                         const isStone = [stoneBlockItemName, stoneFloorItemName, stoneItemName].includes(targetType);
                         const isEarth = [cobItemName, floorItemName].includes(targetType);
 
@@ -6621,6 +6673,7 @@
                     else if (currentBlockType === woodenBlockItemName && woodenBlockMaterialMesh) materialLoaded = true;
                     else if (currentBlockType === stoneFloorItemName && stoneFloorMaterialMesh) materialLoaded = true;
                     else if (currentBlockType === boxItemName && cubeMaterialMesh) materialLoaded = true;
+                    else if (currentBlockType === basketItemName && basketMaterialMesh) materialLoaded = true;
                     else if (currentBlockType === raftItemName && raftMaterialMesh) materialLoaded = true; // NOVO
                     else if (currentBlockType === stoneItemName) materialLoaded = true; // Pedra sempre carregada (usa material básico)
                     else if (currentBlockType === campfireItemName) materialLoaded = true;
@@ -6629,6 +6682,8 @@
                     if (materialLoaded) {
                         if (currentBlockType === boxItemName) {
                             createBox(ghostBlockMesh.position, ghostBlockMesh.quaternion);
+                        } else if (currentBlockType === basketItemName) {
+                            createBasket(ghostBlockMesh.position, ghostBlockMesh.quaternion);
                         } else if (currentBlockType === raftItemName) {
                             createRaft(ghostBlockMesh.position, ghostBlockMesh.quaternion);
                         } else if (currentBlockType === stoneItemName) {
@@ -8577,6 +8632,8 @@
                             ghostBlockMesh.geometry = new THREE.CylinderGeometry(trunkRadius, trunkRadius, trunkHeight, trunkSegments);
                         } else if (currentBlockType === boxItemName) {
                             ghostBlockMesh.geometry = new THREE.BoxGeometry(1, 1, 1);
+                        } else if (currentBlockType === basketItemName) {
+                            ghostBlockMesh.geometry = new THREE.BoxGeometry(0.5, 0.5, 0.5);
                         } else if (currentBlockType === stoneItemName) {
                             ghostBlockMesh.geometry = new THREE.DodecahedronGeometry(0.25, 0);
                             ghostBlockMesh.scale.set(1.2, 0.6, 1.4);
@@ -8639,6 +8696,7 @@
                     else if (currentBlockType === appleSeedItemName || currentBlockType === pineSeedItemName || currentBlockType === coconutItemName || currentBlockType === 'muda_arvore') currentGhostHeight = treeStages['semente'].visual.mound.height;
                     else if (currentBlockType === 'tronco_arvore') currentGhostHeight = trunkHeight;
                     else if (currentBlockType === boxItemName) currentGhostHeight = 1;
+                    else if (currentBlockType === basketItemName) currentGhostHeight = 0.5;
                     else if (currentBlockType === stoneItemName) currentGhostHeight = 0.5;
                     else if (currentBlockType === campfireItemName) currentGhostHeight = 0.5;
                     else if (currentBlockType === torchItemName) currentGhostHeight = 0.8;
@@ -9706,6 +9764,7 @@
             window.dirtMountains = dirtMountains;
             window.useTextures = useTextures;
             window.createBox = createBox;
+            window.createBasket = createBasket;
             window.closingMounds = closingMounds;
             window.calculateWrappedDistance = calculateWrappedDistance;
             window.animate = animate;
@@ -9726,6 +9785,7 @@
             });
             window.cobMaterialMesh = cobMaterialMesh;
             window.cubeMaterialMesh = cubeMaterialMesh;
+            window.basketMaterialMesh = basketMaterialMesh;
             window.renderer = renderer;
             window.camera = camera;
             window.scene = scene;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,18 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "playwright": "^1.59.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -41,13 +41,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "playwright": "^1.59.1"
   }
 }


### PR DESCRIPTION
Implemented the "Cesto de Capim" (Grass Basket) as requested. 

Key features:
- **Dimensions**: Square shape, 0.5 units (half the size of the 1.0 'Caixote').
- **Capacity**: 17 slots, which is approximately 1/3 of the 'Caixote's 50-slot capacity.
- **Visuals**: Uses a greenish material with the existing 'capim' (grass) texture.
- **Functionality**: Fully integrates with the existing container system. Can be placed on the ground, picked up (grab/collect), and opened to store items.
- **UI Improvements**: The container interface now dynamically adjusts its slot count based on the specific container being opened, ensuring the Cesto correctly displays only 17 slots.
- **Availability**: 5 units have been added to the starting crate for immediate use and verification.

---
*PR created automatically by Jules for task [3960646577503074123](https://jules.google.com/task/3960646577503074123) started by @Armandodecampos*