### PR TITLE
Allow bare-handed tree destruction with time penalty

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -6424,12 +6424,6 @@
 
                         if (isTree || isWooden) {
                             materialType = 'wood';
-                            // NOVO: Restrição estrita de machado para árvores
-                            if (isTree && heldItemName !== axeItemName) {
-                                isDestroying = false;
-                                progressContainer.style.display = 'none';
-                                return;
-                            }
                         } else if (isStone) {
                             materialType = 'stone';
                         } else if (isEarth) {


### PR DESCRIPTION
The change removes the early return in the destruction logic that was triggered when attempting to harvest a tree without holding an axe. By removing this block, the interaction now falls through to the general material-based multiplier system. Trees are classified as 'wood', so if no axe is held, the 'weakMultiplier' (10.0) is applied, increasing the destruction time as requested. cleanup of testing-related global exposures was also performed.

---
*PR created automatically by Jules for task [18089757742756876166](https://jules.google.com/task/18089757742756876166) started by @Armandodecampos*