### PR TITLE
Add tree trunks to tree destruction loot

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -7708,6 +7708,7 @@
                                     addItemToInventory(backpackItems, { name: branchItemName, quantity: 3 });
                                     if (treeType === 'apple') {
                                         addItemToInventory(backpackItems, { name: appleSeedItemName, quantity: 1 });
+                                        addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 4 });
                                         if (destroyTargetBody.userData.apples) {
                                             destroyTargetBody.userData.apples.forEach(appleData => {
                                                 if (!appleData.picked) addItemToInventory(backpackItems, { name: appleItemName, quantity: 1 });
@@ -7726,6 +7727,7 @@
                                         if (cocoTreeIndex !== -1) window.coconutTrees.splice(cocoTreeIndex, 1);
                                     } else if (treeType === 'normal') {
                                         addItemToInventory(backpackItems, { name: pineSeedItemName, quantity: 1 });
+                                        addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 7 });
                                     }
                                 } else if (destroyTargetBody.userData.type === stoneItemName || destroyTargetBody.userData.type === stoneBlockItemName || destroyTargetBody.userData.type === stoneFloorItemName) {
                                     addItemToInventory(backpackItems, { name: stoneItemName, quantity: 1 });


### PR DESCRIPTION
Modified tree destruction logic to grant 4 tree trunks when an apple tree is destroyed and 7 tree trunks when a pine tree (normal tree) is destroyed, in addition to existing rewards. Verified that items are added correctly to the backpack.

---
*PR created automatically by Jules for task [4354824114161559851](https://jules.google.com/task/4354824114161559851) started by @Armandodecampos*