### PR TITLE
Update tree destruction yields to include trunks

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -7707,6 +7707,7 @@
                                 if (isTreeObject) {
                                     addItemToInventory(backpackItems, { name: branchItemName, quantity: 3 });
                                     if (treeType === 'apple') {
+                                        addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 4 });
                                         addItemToInventory(backpackItems, { name: appleSeedItemName, quantity: 1 });
                                         if (destroyTargetBody.userData.apples) {
                                             destroyTargetBody.userData.apples.forEach(appleData => {
@@ -7725,6 +7726,7 @@
                                         const cocoTreeIndex = window.coconutTrees.indexOf(destroyTargetBody);
                                         if (cocoTreeIndex !== -1) window.coconutTrees.splice(cocoTreeIndex, 1);
                                     } else if (treeType === 'normal') {
+                                        addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 7 });
                                         addItemToInventory(backpackItems, { name: pineSeedItemName, quantity: 1 });
                                     }
                                 } else if (destroyTargetBody.userData.type === stoneItemName || destroyTargetBody.userData.type === stoneBlockItemName || destroyTargetBody.userData.type === stoneFloorItemName) {

--- a/index.htm
+++ b/index.htm
@@ -7705,29 +7705,33 @@
                                 }
 
                                 if (isTreeObject) {
-                                    addItemToInventory(backpackItems, { name: branchItemName, quantity: 3 });
+                                    if (!addItemToInventory(backpackItems, { name: branchItemName, quantity: 3 }, maxWeight)) itemsToDrop.push({ name: branchItemName, quantity: 3 });
                                     if (treeType === 'apple') {
-                                        addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 4 });
-                                        addItemToInventory(backpackItems, { name: appleSeedItemName, quantity: 1 });
+                                        if (!addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 4 }, maxWeight)) itemsToDrop.push({ name: treeTrunkItemName, quantity: 4 });
+                                        if (!addItemToInventory(backpackItems, { name: appleSeedItemName, quantity: 1 }, maxWeight)) itemsToDrop.push({ name: appleSeedItemName, quantity: 1 });
                                         if (destroyTargetBody.userData.apples) {
                                             destroyTargetBody.userData.apples.forEach(appleData => {
-                                                if (!appleData.picked) addItemToInventory(backpackItems, { name: appleItemName, quantity: 1 });
+                                                if (!appleData.picked) {
+                                                    if (!addItemToInventory(backpackItems, { name: appleItemName, quantity: 1 }, maxWeight)) itemsToDrop.push({ name: appleItemName, quantity: 1 });
+                                                }
                                             });
                                         }
                                         const appleTreeIndex = appleTrees.indexOf(destroyTargetBody);
                                         if (appleTreeIndex !== -1) appleTrees.splice(appleTreeIndex, 1);
                                     } else if (treeType === 'coconut') {
-                                        addItemToInventory(backpackItems, { name: coconutItemName, quantity: 1 }); // Semente/Fruto
+                                        if (!addItemToInventory(backpackItems, { name: coconutItemName, quantity: 1 }, maxWeight)) itemsToDrop.push({ name: coconutItemName, quantity: 1 }); // Semente/Fruto
                                         if (destroyTargetBody.userData.coconuts) {
                                             destroyTargetBody.userData.coconuts.forEach(cocoData => {
-                                                if (!cocoData.picked) addItemToInventory(backpackItems, { name: coconutItemName, quantity: 1 });
+                                                if (!cocoData.picked) {
+                                                    if (!addItemToInventory(backpackItems, { name: coconutItemName, quantity: 1 }, maxWeight)) itemsToDrop.push({ name: coconutItemName, quantity: 1 });
+                                                }
                                             });
                                         }
                                         const cocoTreeIndex = window.coconutTrees.indexOf(destroyTargetBody);
                                         if (cocoTreeIndex !== -1) window.coconutTrees.splice(cocoTreeIndex, 1);
                                     } else if (treeType === 'normal') {
-                                        addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 7 });
-                                        addItemToInventory(backpackItems, { name: pineSeedItemName, quantity: 1 });
+                                        if (!addItemToInventory(backpackItems, { name: treeTrunkItemName, quantity: 10 }, maxWeight)) itemsToDrop.push({ name: treeTrunkItemName, quantity: 10 });
+                                        if (!addItemToInventory(backpackItems, { name: pineSeedItemName, quantity: 1 }, maxWeight)) itemsToDrop.push({ name: pineSeedItemName, quantity: 1 });
                                     }
                                 } else if (destroyTargetBody.userData.type === stoneItemName || destroyTargetBody.userData.type === stoneBlockItemName || destroyTargetBody.userData.type === stoneFloorItemName) {
                                     addItemToInventory(backpackItems, { name: stoneItemName, quantity: 1 });
@@ -7746,6 +7750,8 @@
                                         addItemToInventory(backpackItems, { name: type, quantity: 1 });
                                     }
                                 }
+                                updateUI();
+                                updateBackpackDisplay();
 
                                 // Remove o corpo e a malha PRIMEIRO para evitar colisões indesejadas com os itens dropados
                                 world.removeBody(destroyTargetBody);


### PR DESCRIPTION
Modified the tree destruction logic in index.htm to grant 4 'tronco_arvore' items when an apple tree is destroyed and 7 'tronco_arvore' items when a normal (pine) tree is destroyed. This is in addition to the existing item drops.

---
*PR created automatically by Jules for task [9253819034330689414](https://jules.google.com/task/9253819034330689414) started by @Armandodecampos*