### PR TITLE
Adição de Ferramentas de Ferro (Machado, Martelo, Picareta, Pá)

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1342,6 +1342,10 @@
         // NOVO: Variáveis para o sistema de destruição de blocos (Machado e Martelo)
         const axeItemName = 'machado'; // Nome do item de machado no inventário
         const hammerItemName = 'martelo'; // Nome do item de martelo no inventário
+        const ironAxeItemName = 'machado_ferro';
+        const ironHammerItemName = 'martelo_ferro';
+        const ironShovelItemName = 'pá_ferro';
+        const ironPickaxeItemName = 'picareta_ferro';
         const stoneItemName = 'pedra'; // NOVO: Nome do item de pedra no inventário
         const ironOreItemName = 'minerio_ferro'; // NOVO: Nome do item de minério de ferro
         const dirtItemName = 'terra'; // NOVO: Nome do item de terra no inventário
@@ -1381,14 +1385,18 @@
             [pineSeedItemName]: 'Pinhão',
             [coconutSeedItemName]: 'Semente de Coqueiro',
             [coconutItemName]: 'Coco',
-            [axeItemName]: 'Machado\nEspecialidade: Madeira',
-            [hammerItemName]: 'Martelo\nSem uso',
+            [axeItemName]: 'Machado de Pedra\nEspecialidade: Madeira',
+            [hammerItemName]: 'Martelo de Pedra\nSem uso',
+            [ironAxeItemName]: 'Machado de Ferro\nEspecialidade: Madeira',
+            [ironHammerItemName]: 'Martelo de Ferro\nSem uso',
+            [ironShovelItemName]: 'Pá de Ferro\nEspecialidade: Terra',
+            [ironPickaxeItemName]: 'Picareta de Ferro\nEspecialidade: Pedra',
             [stoneItemName]: 'Pedra',
             [ironOreItemName]: 'Minério de Ferro',
             [dirtItemName]: 'Terra',
             [sandItemName]: 'Areia',
-            [shovelItemName]: 'Pá\nEspecialidade: Terra',
-            [pickaxeItemName]: 'Picareta\nEspecialidade: Pedra',
+            [shovelItemName]: 'Pá de Pedra\nEspecialidade: Terra',
+            [pickaxeItemName]: 'Picareta de Pedra\nEspecialidade: Pedra',
             [cobItemName]: 'Bloco de Barro',
             [floorItemName]: 'Piso de Barro',
             [treeSaplingItemName]: 'Muda de Árvore',
@@ -1421,6 +1429,10 @@
             [coconutItemName]: 0.3,
             [axeItemName]: 2.0,
             [hammerItemName]: 2.0,
+            [ironAxeItemName]: 3.0,
+            [ironHammerItemName]: 3.0,
+            [ironShovelItemName]: 3.0,
+            [ironPickaxeItemName]: 3.0,
             [stoneItemName]: 1.0,
             [ironOreItemName]: 0.8,
             [dirtItemName]: 0.2,
@@ -2070,6 +2082,10 @@
             if (itemName === axeItemName) return axeImageURL;
             if (itemName === capimItemName) return capimImageURL;
             if (itemName === hammerItemName) return hammerImageURL;
+            if (itemName === ironAxeItemName) return "https://placehold.co/100x100/A9A9A9/FFFFFF?text=Machado+Ferro";
+            if (itemName === ironHammerItemName) return "https://placehold.co/100x100/A9A9A9/FFFFFF?text=Martelo+Ferro";
+            if (itemName === ironShovelItemName) return "https://placehold.co/100x100/A9A9A9/FFFFFF?text=Pá+Ferro";
+            if (itemName === ironPickaxeItemName) return "https://placehold.co/100x100/A9A9A9/FFFFFF?text=Picareta+Ferro";
             if (itemName === stoneItemName) return stoneImageURL;
             if (itemName === dirtItemName) return dirtImageURL;
             if (itemName === sandItemName) return sandImageURL;
@@ -5810,6 +5826,10 @@
             addItemToInventory(startingChestInventory, { name: woodenBlockItemName, quantity: 100 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: stoneFloorItemName, quantity: 100 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: axeItemName, quantity: 1 }, startingChestMaxWeight, true);
+            addItemToInventory(startingChestInventory, { name: ironAxeItemName, quantity: 1 }, startingChestMaxWeight, true);
+            addItemToInventory(startingChestInventory, { name: ironHammerItemName, quantity: 1 }, startingChestMaxWeight, true);
+            addItemToInventory(startingChestInventory, { name: ironShovelItemName, quantity: 1 }, startingChestMaxWeight, true);
+            addItemToInventory(startingChestInventory, { name: ironPickaxeItemName, quantity: 1 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: ropeItemName, quantity: 10 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: fabricItemName, quantity: 10 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: campfireItemName, quantity: 5 }, startingChestMaxWeight, true);
@@ -6212,7 +6232,7 @@
                 if (item === null) return 'grab';
                 // Ferramentas de destruição e modificação de terreno
                 // O martelo foi removido temporariamente das ferramentas de destruição
-                if (item.name === axeItemName || item.name === pickaxeItemName || item.name === shovelItemName || item.name === branchItemName || item.name === dirtItemName || item.name === sandItemName) return 'destroy';
+                if (item.name === axeItemName || item.name === pickaxeItemName || item.name === shovelItemName || item.name === ironAxeItemName || item.name === ironPickaxeItemName || item.name === ironShovelItemName || item.name === branchItemName || item.name === dirtItemName || item.name === sandItemName) return 'destroy';
                 // Itens de colocação
                 if (item.name === cobItemName || item.name === floorItemName || item.name === treeSaplingItemName || item.name === appleSeedItemName || item.name === pineSeedItemName || item.name === coconutItemName || item.name === woodenPlankItemName || item.name === treeTrunkItemName || item.name === boxItemName || item.name === basketItemName || item.name === raftItemName || item.name === stoneBlockItemName || item.name === woodenBlockItemName || item.name === stoneFloorItemName || item.name === stoneItemName || item.name === campfireItemName || item.name === torchItemName) return 'place';
                 return null; // Retorna nulo se o item não tiver um tipo de ação conhecido
@@ -6235,6 +6255,9 @@
                                      heldItemName === axeItemName ||
                                      heldItemName === pickaxeItemName ||
                                      heldItemName === shovelItemName ||
+                                     heldItemName === ironAxeItemName ||
+                                     heldItemName === ironPickaxeItemName ||
+                                     heldItemName === ironShovelItemName ||
                                      heldItemName === branchItemName ||
                                      heldItemName === dirtItemName ||
                                      heldItemName === sandItemName;
@@ -6245,7 +6268,7 @@
                 if ((heldItemName === dirtItemName || heldItemName === sandItemName) && heldItemQuantity <= 0) return;
 
                 // Impede a destruição com o martelo (já coberto pelo isAllowedTool, mas mantido por clareza)
-                if (heldItemName === hammerItemName) {
+                if (heldItemName === hammerItemName || heldItemName === ironHammerItemName) {
                     return;
                 }
 
@@ -6294,10 +6317,10 @@
                 }
 
                 // Priorização baseada na ferramenta
-                if (heldItemName === shovelItemName) {
+                if (heldItemName === shovelItemName || heldItemName === ironShovelItemName) {
                     // Prioriza capim se estiver mirando nele, para facilitar a limpeza antes de cavar
                     target = potentialCapim || potentialGround || potentialObject;
-                } else if (heldItemName === axeItemName || heldItemName === pickaxeItemName) {
+                } else if (heldItemName === axeItemName || heldItemName === pickaxeItemName || heldItemName === ironAxeItemName || heldItemName === ironPickaxeItemName) {
                     target = potentialObject || potentialCapim || potentialGround;
                 } else if (heldItemName === dirtItemName || heldItemName === sandItemName) {
                     target = potentialGround || potentialObject || potentialCapim;
@@ -6468,19 +6491,27 @@
                     const isBuildingAction = (heldItemName === dirtItemName || heldItemName === sandItemName);
 
                     // Define a ferramenta correta para cada material
+                    const isIronTool = (heldItemName === ironAxeItemName || heldItemName === ironPickaxeItemName || heldItemName === ironShovelItemName);
                     const isCorrectTool = isBuildingAction ||
-                        (heldItemName === axeItemName && materialType === 'wood') ||
-                        (heldItemName === pickaxeItemName && materialType === 'stone') ||
-                        (heldItemName === shovelItemName && materialType === 'earth');
+                        ((heldItemName === axeItemName || heldItemName === ironAxeItemName) && materialType === 'wood') ||
+                        ((heldItemName === pickaxeItemName || heldItemName === ironPickaxeItemName) && materialType === 'stone') ||
+                        ((heldItemName === shovelItemName || heldItemName === ironShovelItemName) && materialType === 'earth');
 
                     if (isCorrectTool) {
                         if (isBuildingAction) {
                             multiplier = 1.0;
                         } else if ((heldItemName === shovelItemName && materialType === 'earth') ||
-                            (heldItemName === pickaxeItemName && materialType === 'stone')) {
+                            (heldItemName === pickaxeItemName && materialType === 'stone') ||
+                            (heldItemName === ironShovelItemName && materialType === 'earth') ||
+                            (heldItemName === ironPickaxeItemName && materialType === 'stone')) {
                             multiplier = 0.3; // Mais rápido com a ferramenta correta
                         } else {
                             multiplier = strongMultiplier;
+                        }
+
+                        // Aplica bônus de velocidade para ferramentas de ferro (faz as funções mais rápido)
+                        if (isIronTool) {
+                            multiplier *= 0.5; // Dobro da velocidade
                         }
                     } else if (heldItemName === branchItemName && (materialType === 'stone' || materialType === 'earth')) {
                         multiplier = branchMultiplier;
@@ -8484,7 +8515,7 @@
             } else if (actionType === 'destroy') {
                 isPrimaryToolDestroying = true;
                 // NOVO: Se for uma ferramenta que cava terra ou o próprio item Terra, preparamos o ghost de terra
-                if (primaryTool === null || primaryTool.name === shovelItemName || primaryTool.name === pickaxeItemName || primaryTool.name === axeItemName || primaryTool.name === dirtItemName) {
+                if (primaryTool === null || primaryTool.name === shovelItemName || primaryTool.name === pickaxeItemName || primaryTool.name === axeItemName || primaryTool.name === ironShovelItemName || primaryTool.name === ironPickaxeItemName || primaryTool.name === ironAxeItemName || primaryTool.name === dirtItemName) {
                     currentBlockType = dirtItemName;
                 }
             } else if (actionType === 'place') {


### PR DESCRIPTION
This PR introduces four new iron tools: Machado de Ferro, Martelo de Ferro, Picareta de Ferro, and Pá de Ferro. These tools function identically to their stone counterparts but are 2x faster at performing their respective tasks (chopping wood, mining stone, or digging earth). Stone tools have been renamed to include "de Pedra" to distinguish them from the new iron versions. One of each iron tool is now provided in the starting chest.

---
*PR created automatically by Jules for task [3548508147212429566](https://jules.google.com/task/3548508147212429566) started by @Armandodecampos*