### PR TITLE
Add "Barra de ferro" item and pre-populate starting crate

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1348,6 +1348,7 @@
         const ironPickaxeItemName = 'picareta_ferro';
         const stoneItemName = 'pedra'; // NOVO: Nome do item de pedra no inventário
         const ironOreItemName = 'minerio_ferro'; // NOVO: Nome do item de minério de ferro
+        const ironBarItemName = 'barra_ferro'; // NOVO: Nome do item de barra de ferro
         const dirtItemName = 'terra'; // NOVO: Nome do item de terra no inventário
         const sandItemName = 'areia'; // NOVO: Nome do item de areia no inventário
         const shovelItemName = 'pá'; // NOVO: Nome do item de pá no inventário
@@ -1393,6 +1394,7 @@
             [ironPickaxeItemName]: 'Picareta de Ferro\nEspecialidade: Pedra',
             [stoneItemName]: 'Pedra',
             [ironOreItemName]: 'Minério de Ferro',
+            [ironBarItemName]: 'Barra de Ferro',
             [dirtItemName]: 'Terra',
             [sandItemName]: 'Areia',
             [shovelItemName]: 'Pá de Pedra\nEspecialidade: Terra',
@@ -1435,6 +1437,7 @@
             [ironPickaxeItemName]: 3.0,
             [stoneItemName]: 1.0,
             [ironOreItemName]: 0.8,
+            [ironBarItemName]: 2.0,
             [dirtItemName]: 0.2,
             [sandItemName]: 0.2,
             [shovelItemName]: 2.0,
@@ -2086,6 +2089,7 @@
             if (itemName === ironHammerItemName) return "https://placehold.co/100x100/A9A9A9/FFFFFF?text=Martelo+Ferro";
             if (itemName === ironShovelItemName) return "https://placehold.co/100x100/A9A9A9/FFFFFF?text=Pá+Ferro";
             if (itemName === ironPickaxeItemName) return "https://placehold.co/100x100/A9A9A9/FFFFFF?text=Picareta+Ferro";
+            if (itemName === ironBarItemName) return "https://placehold.co/100x100/808080/FFFFFF?text=Barra+Ferro";
             if (itemName === stoneItemName) return stoneImageURL;
             if (itemName === dirtItemName) return dirtImageURL;
             if (itemName === sandItemName) return sandImageURL;
@@ -5830,6 +5834,7 @@
             addItemToInventory(startingChestInventory, { name: ironHammerItemName, quantity: 1 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: ironShovelItemName, quantity: 1 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: ironPickaxeItemName, quantity: 1 }, startingChestMaxWeight, true);
+            addItemToInventory(startingChestInventory, { name: ironBarItemName, quantity: 10 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: ropeItemName, quantity: 10 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: fabricItemName, quantity: 10 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: campfireItemName, quantity: 5 }, startingChestMaxWeight, true);


### PR DESCRIPTION
Added the "Barra de ferro" item to the game. It is now defined in the item system with a display name, weight, and icon, and the player starts with 10 units of it in the initial 'Caixote' crate.

---
*PR created automatically by Jules for task [15005755416223867667](https://jules.google.com/task/15005755416223867667) started by @Armandodecampos*