### PR TITLE
Redesign bancada_trabalho and restrict mesa/workbench grabbing

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -4402,7 +4402,8 @@
                 blockBody.userData.fireOffset = Math.random() * 1000;
                 activeCampfires.push(blockBody);
             } else if (type === workbenchItemName || type === mesaItemName) {
-                width = 1.2; height = 0.85; depth = 0.7;
+                width = type === workbenchItemName ? 1.6 : 1.2;
+                height = 0.85; depth = 0.7;
                 blockShape = new CANNON.Box(new CANNON.Vec3(width / 2, height / 2, depth / 2));
                 blockBody.addShape(blockShape);
 
@@ -4411,7 +4412,7 @@
                 const metalMat = new THREE.MeshStandardMaterial({ color: 0x708090 }); // Slate Gray
 
                 // Table Top
-                const topGeom = new THREE.BoxGeometry(1.2, 0.1, 0.7);
+                const topGeom = new THREE.BoxGeometry(width, 0.1, 0.7);
                 const topMesh = new THREE.Mesh(topGeom, woodMat);
                 topMesh.position.y = 0.35;
                 topMesh.castShadow = true;
@@ -4420,11 +4421,12 @@
 
                 // Legs
                 const legGeom = new THREE.BoxGeometry(0.1, 0.75, 0.1);
+                const legX = width / 2 - 0.1;
                 const legPositions = [
-                    { x: 0.5, z: 0.25 },
-                    { x: -0.5, z: 0.25 },
-                    { x: 0.5, z: -0.25 },
-                    { x: -0.5, z: -0.25 }
+                    { x: legX, z: 0.25 },
+                    { x: -legX, z: 0.25 },
+                    { x: legX, z: -0.25 },
+                    { x: -legX, z: -0.25 }
                 ];
                 legPositions.forEach(pos => {
                     const leg = new THREE.Mesh(legGeom, woodMat);
@@ -4439,7 +4441,7 @@
                     const drawerUnitGeom = new THREE.BoxGeometry(0.35, 0.45, 0.6);
                     const handleGeom = new THREE.BoxGeometry(0.15, 0.03, 0.03);
 
-                    [-0.275, 0.275].forEach(xPos => {
+                    [-0.45, 0.45].forEach(xPos => {
                         const unit = new THREE.Mesh(drawerUnitGeom, woodMat);
                         unit.position.set(xPos, 0.075, 0);
                         unit.castShadow = true;


### PR DESCRIPTION
- Increase bancada_trabalho width to 1.6 units and sync physics body.
- Remove metal box from workbench top.
- Add two drawer units with metal handles under the workbench.
- Update grabObject logic and UI hints to prevent physical grabbing (F) of mesa and bancada_trabalho, while allowing collection (G).
- Synchronize workbench leg positions with new width.