### PR TITLE
Redesign bancada_trabalho (wider) and restrict mesa/workbench grabbing

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -4402,7 +4402,7 @@
                 blockBody.userData.fireOffset = Math.random() * 1000;
                 activeCampfires.push(blockBody);
             } else if (type === workbenchItemName || type === mesaItemName) {
-                width = type === workbenchItemName ? 1.6 : 1.2;
+                width = type === workbenchItemName ? 2.0 : 1.2;
                 height = 0.85; depth = 0.7;
                 blockShape = new CANNON.Box(new CANNON.Vec3(width / 2, height / 2, depth / 2));
                 blockBody.addShape(blockShape);
@@ -4441,7 +4441,7 @@
                     const drawerUnitGeom = new THREE.BoxGeometry(0.35, 0.45, 0.6);
                     const handleGeom = new THREE.BoxGeometry(0.15, 0.03, 0.03);
 
-                    [-0.45, 0.45].forEach(xPos => {
+                    [-0.65, 0.65].forEach(xPos => {
                         const unit = new THREE.Mesh(drawerUnitGeom, woodMat);
                         unit.position.set(xPos, 0.075, 0);
                         unit.castShadow = true;


### PR DESCRIPTION
- Increase bancada_trabalho width to 2.0 units and sync physics body.
- Remove metal box from workbench top.
- Add two drawer units with metal handles under the workbench (one on each side).
- Update grabObject logic and UI hints to prevent physical grabbing (F) of mesa and bancada_trabalho, while allowing collection (G).
- Synchronize workbench leg positions with the 2.0 width.