### PR TITLE
Add 'Forno' (Furnace) item

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1380,6 +1380,7 @@
         const workbenchItemName = 'bancada_trabalho';
         const mesaItemName = 'mesa';
         const bigornaItemName = 'bigorna';
+        const furnaceItemName = 'forno';
 
         // NOVO: Mapeamento de nomes de itens para exibição
         window.itemDisplayNames = {
@@ -1425,7 +1426,8 @@
             [pestleItemName]: 'Pilão',
             [workbenchItemName]: 'Bancada de Trabalho',
             [mesaItemName]: 'Mesa',
-            [bigornaItemName]: 'Bigorna'
+            [bigornaItemName]: 'Bigorna',
+            [furnaceItemName]: 'Forno\nUsado para processar materiais'
         };
 
         window.itemWeights = {
@@ -1471,7 +1473,8 @@
             [pestleItemName]: 1.5,
             [workbenchItemName]: 15.0,
             [mesaItemName]: 10.0,
-            [bigornaItemName]: 20.0
+            [bigornaItemName]: 20.0,
+            [furnaceItemName]: 30.0
         };
 
         const maxWeight = 500; // Peso máximo que o jogador aguenta levar
@@ -2113,6 +2116,7 @@
             if (itemName === woodenPlankItemName) return woodenPlankTextureURL;
             if (itemName === raftItemName) return treeBarkTextureURL;
             if (itemName === stoneBlockItemName) return stoneBlockTextureURL;
+            if (itemName === furnaceItemName) return "https://placehold.co/100x100/444444/FFFFFF?text=Forno";
             if (itemName === woodenBlockItemName) return woodenBlockTextureURL;
             if (itemName === stoneFloorItemName) return stoneFloorTextureURL;
             if (itemName === boxItemName) return cubeTextureURL;
@@ -4501,6 +4505,95 @@
                 mesh = group;
                 initialMass = 150;
                 durability = 3.0;
+            } else if (type === furnaceItemName) {
+                ensureTorchAssets();
+                width = 1.0; height = 1.2; depth = 1.0;
+                blockShape = new CANNON.Box(new CANNON.Vec3(width / 2, height / 2, depth / 2));
+                blockBody.addShape(blockShape);
+
+                const furnaceGroup = new THREE.Group();
+                const stoneMat = stoneBlockMaterialMesh; // Reuso do material de pedra cinza
+
+                // Main body (Hollow-ish look)
+                // We'll build it with 4 walls and a top to create the "openings" feel
+
+                // Back Wall
+                const backWall = new THREE.Mesh(new THREE.BoxGeometry(1.0, 1.2, 0.2), stoneMat);
+                backWall.position.z = -0.4;
+                backWall.castShadow = true;
+                backWall.receiveShadow = true;
+                furnaceGroup.add(backWall);
+
+                // Side Walls
+                const leftWall = new THREE.Mesh(new THREE.BoxGeometry(0.2, 1.2, 0.8), stoneMat);
+                leftWall.position.x = -0.4;
+                leftWall.position.z = 0.1;
+                leftWall.castShadow = true;
+                leftWall.receiveShadow = true;
+                furnaceGroup.add(leftWall);
+
+                const rightWall = new THREE.Mesh(new THREE.BoxGeometry(0.2, 1.2, 0.8), stoneMat);
+                rightWall.position.x = 0.4;
+                rightWall.position.z = 0.1;
+                rightWall.castShadow = true;
+                rightWall.receiveShadow = true;
+                furnaceGroup.add(rightWall);
+
+                // Top Slab
+                const topSlab = new THREE.Mesh(new THREE.BoxGeometry(1.0, 0.2, 1.0), stoneMat);
+                topSlab.position.y = 0.5;
+                topSlab.castShadow = true;
+                topSlab.receiveShadow = true;
+                furnaceGroup.add(topSlab);
+
+                // Middle Divider (separating lower fuel area from upper cooking area)
+                const middleSlab = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.1, 0.8), stoneMat);
+                middleSlab.position.y = -0.1;
+                middleSlab.position.z = 0.1;
+                middleSlab.castShadow = true;
+                middleSlab.receiveShadow = true;
+                furnaceGroup.add(middleSlab);
+
+                // Bottom Front Lip
+                const bottomLip = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.1, 0.2), stoneMat);
+                bottomLip.position.y = -0.55;
+                bottomLip.position.z = 0.4;
+                bottomLip.castShadow = true;
+                bottomLip.receiveShadow = true;
+                furnaceGroup.add(bottomLip);
+
+                // Fire inside (Lower part)
+                const fireGroup = new THREE.Group();
+                const furnaceFireLayers = [
+                    { mat: torchOrangeFireMat, s: { w: 0.5, h: 0.7 }, speed: 0.8, offset: 0 },
+                    { mat: torchYellowFireMat, s: { w: 0.3, h: 0.5 }, speed: 1.1, offset: 0.3 },
+                    { mat: torchCoreFireMat, s: { w: 0.1, h: 0.3 }, speed: 1.4, offset: 0.6 }
+                ];
+
+                furnaceFireLayers.forEach(layer => {
+                    const fire = new THREE.Mesh(torchFireGeom, layer.mat);
+                    fire.scale.set(layer.s.w, layer.s.h, layer.s.w);
+                    fire.userData.baseScale = { x: layer.s.w, y: layer.s.h, z: layer.s.w };
+                    fire.userData.animSpeed = layer.speed;
+                    fire.userData.animOffset = layer.offset;
+                    fire.position.y = -0.45;
+                    fire.position.z = 0.1;
+                    fireGroup.add(fire);
+                });
+                furnaceGroup.add(fireGroup);
+
+                const light = new THREE.PointLight(0xffaa00, 2, 6);
+                light.position.set(0, -0.2, 0.2);
+                furnaceGroup.add(light);
+
+                mesh = furnaceGroup;
+                initialMass = 200;
+                durability = 5.0;
+
+                blockBody.userData.fireGroup = fireGroup;
+                blockBody.userData.fireLight = light;
+                blockBody.userData.fireOffset = Math.random() * 1000;
+                activeCampfires.push(blockBody);
             }
             else {
                 console.error('Tipo de bloco desconhecido:', type);
@@ -4509,7 +4602,7 @@
 
             world.addBody(blockBody);
             Object.assign(blockBody.userData, {
-                isCollectible: (type === workbenchItemName || type === mesaItemName || type === bigornaItemName),
+                isCollectible: (type === workbenchItemName || type === mesaItemName || type === bigornaItemName || type === furnaceItemName),
                 isDestructible: true,
                 durability: durability,
                 originalMass: initialMass,
@@ -5948,6 +6041,7 @@
             addItemToInventory(startingChestInventory, { name: ropeItemName, quantity: 10 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: fabricItemName, quantity: 10 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: campfireItemName, quantity: 5 }, startingChestMaxWeight, true);
+            addItemToInventory(startingChestInventory, { name: furnaceItemName, quantity: 10 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: torchItemName, quantity: 10 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: vegetableOilItemName, quantity: 5 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: workbenchToolkitItemName, quantity: 1 }, startingChestMaxWeight, true);
@@ -6354,7 +6448,7 @@
                 // O martelo foi removido temporariamente das ferramentas de destruição
                 if (item.name === axeItemName || item.name === pickaxeItemName || item.name === shovelItemName || item.name === ironAxeItemName || item.name === ironPickaxeItemName || item.name === ironShovelItemName || item.name === branchItemName || item.name === dirtItemName || item.name === sandItemName) return 'destroy';
                 // Itens de colocação
-                if (item.name === cobItemName || item.name === floorItemName || item.name === treeSaplingItemName || item.name === appleSeedItemName || item.name === pineSeedItemName || item.name === coconutItemName || item.name === woodenPlankItemName || item.name === treeTrunkItemName || item.name === boxItemName || item.name === basketItemName || item.name === raftItemName || item.name === stoneBlockItemName || item.name === woodenBlockItemName || item.name === stoneFloorItemName || item.name === stoneItemName || item.name === campfireItemName || item.name === torchItemName || item.name === workbenchItemName || item.name === mesaItemName || item.name === bigornaItemName) return 'place';
+                if (item.name === cobItemName || item.name === floorItemName || item.name === treeSaplingItemName || item.name === appleSeedItemName || item.name === pineSeedItemName || item.name === coconutItemName || item.name === woodenPlankItemName || item.name === treeTrunkItemName || item.name === boxItemName || item.name === basketItemName || item.name === raftItemName || item.name === stoneBlockItemName || item.name === woodenBlockItemName || item.name === stoneFloorItemName || item.name === stoneItemName || item.name === campfireItemName || item.name === torchItemName || item.name === workbenchItemName || item.name === mesaItemName || item.name === bigornaItemName || item.name === furnaceItemName) return 'place';
                 return null; // Retorna nulo se o item não tiver um tipo de ação conhecido
             }
 
@@ -6814,7 +6908,7 @@
                             updateBackpackDisplay();
                             break;
                         }
-                    } else if (clickedBody.userData.type === workbenchItemName || clickedBody.userData.type === mesaItemName || clickedBody.userData.type === bigornaItemName) {
+                    } else if (clickedBody.userData.type === workbenchItemName || clickedBody.userData.type === mesaItemName || clickedBody.userData.type === bigornaItemName || clickedBody.userData.type === furnaceItemName) {
                         const constructionIndex = placedConstructionBodies.indexOf(clickedBody);
                         if (constructionIndex > -1) {
                             const type = clickedBody.userData.type;
@@ -6849,7 +6943,7 @@
                         current = current.parent;
                     }
 
-                    if (body && (allPickableBodies.includes(body) || (allConstructionBodies.includes(body) && body.userData.isCollectible)) && body.userData.type !== campfireItemName && body.userData.type !== workbenchItemName && body.userData.type !== mesaItemName && body.userData.type !== bigornaItemName) {
+                    if (body && (allPickableBodies.includes(body) || (allConstructionBodies.includes(body) && body.userData.isCollectible)) && body.userData.type !== campfireItemName && body.userData.type !== workbenchItemName && body.userData.type !== mesaItemName && body.userData.type !== bigornaItemName && body.userData.type !== furnaceItemName) {
                         if (intersects[i].distance <= pickUpDistance) {
                             pickedObjectBody = body;
                             pickedObjectMesh = intersects[i].object;
@@ -6936,7 +7030,7 @@
                     else if (currentBlockType === stoneItemName) materialLoaded = true; // Pedra sempre carregada (usa material básico)
                     else if (currentBlockType === campfireItemName) materialLoaded = true;
                     else if (currentBlockType === torchItemName) materialLoaded = true;
-                    else if (currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName) materialLoaded = true;
+                    else if (currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName || currentBlockType === furnaceItemName) materialLoaded = true;
 
                     if (materialLoaded) {
                         if (currentBlockType === boxItemName) {
@@ -8700,7 +8794,7 @@
                                 break;
                             }
                             if (body.userData.isCollectible) {
-                                if (body.userData.type === workbenchItemName || body.userData.type === mesaItemName || body.userData.type === bigornaItemName) {
+                                if (body.userData.type === workbenchItemName || body.userData.type === mesaItemName || body.userData.type === bigornaItemName || body.userData.type === furnaceItemName) {
                                     interactionHintText = "(G) Guardar";
                                 } else {
                                     interactionHintText = "(F) Agarrar / (G) Guardar";
@@ -9006,6 +9100,7 @@
 
                     // Determina a altura para o cálculo de posicionamento (não muda cada frame, mas precisamos dela)
                     if (currentBlockType === raftItemName) currentGhostHeight = 0.4;
+                    else if (currentBlockType === furnaceItemName) currentGhostHeight = 1.2;
                     else if (currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName) currentGhostHeight = 0.85;
                     else if (currentBlockType === 'cob') currentGhostHeight = cobHeight;
                     else if (currentBlockType === 'piso') currentGhostHeight = floorHeight;
@@ -9090,7 +9185,7 @@
                                 // NOVO: Alinha a posição Y na grade, considerando a altura da superfície da ilha como a base.
                                 // Isso garante que os blocos se encaixem verticalmente.
                                 // CORREÇÃO: As sementes não devem se encaixar na grade vertical, elas devem ser colocadas no chão.
-                                if (currentBlockType === 'muda_arvore' || currentBlockType === appleSeedItemName || currentBlockType === pineSeedItemName || currentBlockType === coconutItemName || currentBlockType === dirtItemName || currentBlockType === sandItemName || currentBlockType === raftItemName || currentBlockType === torchItemName || currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName) {
+                                if (currentBlockType === 'muda_arvore' || currentBlockType === appleSeedItemName || currentBlockType === pineSeedItemName || currentBlockType === coconutItemName || currentBlockType === dirtItemName || currentBlockType === sandItemName || currentBlockType === raftItemName || currentBlockType === torchItemName || currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName || currentBlockType === furnaceItemName) {
                                     placementPosition.y = basePosition.y;
                                 } else if (currentBlockType === boxItemName) {
                                     placementPosition.y = basePosition.y;


### PR DESCRIPTION
This PR adds a new placeable item called "Forno" (Furnace). 

Key features:
- **Visuals:** A primitive stone structure built from multiple meshes to create a hollow interior with two distinct openings (lower for fuel, upper for processing). Includes a dynamic 3-layer fire effect and internal lighting.
- **Mechanics:** The furnace is a heavy item (30kg) that can be placed on the ground and collected into the inventory (G key). Physical grabbing (F key) is disabled to match other large workshop items.
- **Initial Setup:** The starting crate at (0, -5) now contains 10 Furnaces to allow immediate testing and use.
- **Technical Integration:** Reuses the `activeCampfires` animation loop for fire effects and follows the established `createPlaceableBlock` pattern for new structures.

---
*PR created automatically by Jules for task [506636777331837054](https://jules.google.com/task/506636777331837054) started by @Armandodecampos*