### PR TITLE
feat: add firewood logs to 'Forno' (Furnace) item

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -4556,6 +4556,22 @@
                 bottomLip.position.set(0, -0.55, 0.4);
                 bottomLip.castShadow = true;
                 bottomLip.receiveShadow = true;
+                // Firewood Logs in the lower opening
+                const logGeom = new THREE.CylinderGeometry(0.06, 0.06, 0.5, 8);
+                const logMat = woodenBlockMaterialMesh;
+                const logPositions = [
+                    { x: -0.15, z: 0.1, rotZ: Math.PI / 2, rotX: 0.2 },
+                    { x: 0.15, z: 0.2, rotZ: Math.PI / 2, rotX: -0.3 },
+                    { x: 0, z: 0.3, rotZ: Math.PI / 2, rotX: 0.1 }
+                ];
+                logPositions.forEach(pos => {
+                    const log = new THREE.Mesh(logGeom, logMat);
+                    log.rotation.set(pos.rotX, 0, pos.rotZ);
+                    log.position.set(pos.x, -0.45, pos.z);
+                    log.castShadow = true;
+                    log.receiveShadow = true;
+                    furnaceGroup.add(log);
+                });
                 furnaceGroup.add(bottomLip);
 
                 // Fire inside (Lower part)


### PR DESCRIPTION
- Added procedural wood logs to the lower opening of the furnace model.
- Used CylinderGeometry and woodenBlockMaterialMesh for the logs.
- Positioned and rotated logs to enhance the primitive aesthetic.
- Ensured logs are correctly integrated into the furnace group.