### PR TITLE
Complete crafting system and workstation menus with Pilão placement fix

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -7429,7 +7429,7 @@
                     else if (currentBlockType === stoneItemName) materialLoaded = true; // Pedra sempre carregada (usa material básico)
                     else if (currentBlockType === campfireItemName) materialLoaded = true;
                     else if (currentBlockType === torchItemName) materialLoaded = true;
-                    else if (currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName || currentBlockType === furnaceItemName) materialLoaded = true;
+                    else if (currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName || currentBlockType === furnaceItemName || currentBlockType === pestleItemName) materialLoaded = true;
 
                     if (materialLoaded) {
                         if (currentBlockType === boxItemName) {
@@ -7490,7 +7490,8 @@
                     primaryToolForVisuals.name === boxItemName ||
                     primaryToolForVisuals.name === stoneBlockItemName ||
                     primaryToolForVisuals.name === woodenBlockItemName ||
-                    primaryToolForVisuals.name === stoneItemName
+                    primaryToolForVisuals.name === stoneItemName ||
+                    primaryToolForVisuals.name === pestleItemName
                 );
                 const isPrimaryToolGrabbing = primaryToolForVisuals === null; // Hand is active if slot 0 is null
 
@@ -9537,6 +9538,7 @@
                     else if (currentBlockType === stoneItemName) currentGhostHeight = 0.5;
                     else if (currentBlockType === campfireItemName) currentGhostHeight = 0.5;
                     else if (currentBlockType === torchItemName) currentGhostHeight = 0.8;
+                    else if (currentBlockType === pestleItemName) currentGhostHeight = 0.5;
                     // Update ghost block geometry
                     // ghostBlockMesh.geometry = new THREE.BoxGeometry(currentGhostWidth, currentGhostHeight, currentGhostDepth); // Removido para lidar individualmente
 
@@ -9607,7 +9609,7 @@
                                 // NOVO: Alinha a posição Y na grade, considerando a altura da superfície da ilha como a base.
                                 // Isso garante que os blocos se encaixem verticalmente.
                                 // CORREÇÃO: As sementes não devem se encaixar na grade vertical, elas devem ser colocadas no chão.
-                                if (currentBlockType === 'muda_arvore' || currentBlockType === appleSeedItemName || currentBlockType === pineSeedItemName || currentBlockType === coconutItemName || currentBlockType === dirtItemName || currentBlockType === sandItemName || currentBlockType === raftItemName || currentBlockType === torchItemName || currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName || currentBlockType === furnaceItemName) {
+                                if (currentBlockType === 'muda_arvore' || currentBlockType === appleSeedItemName || currentBlockType === pineSeedItemName || currentBlockType === coconutItemName || currentBlockType === dirtItemName || currentBlockType === sandItemName || currentBlockType === raftItemName || currentBlockType === torchItemName || currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName || currentBlockType === furnaceItemName || currentBlockType === pestleItemName) {
                                     placementPosition.y = basePosition.y;
                                 } else if (currentBlockType === boxItemName) {
                                     placementPosition.y = basePosition.y;


### PR DESCRIPTION
- Implemented multiple crafting menus (Initial, Furnace, Anvil, Pestle, Workbench).
- Added all requested recipes with ingredient consumption and weight checks.
- Added 'Pilão' (Pestle) item with procedural 3D model.
- Fixed issue preventing 'Pilão' from being placed on the ground.
- Added ghost block preview for the 'Pilão'.
- Registered display names, weights, and icons for all new items (Iron Bar, Clay Pot, Anvil, etc.).
- Improved interaction logic to open specific menus when clicking on workstations.