### PR TITLE
Update Pilão Recipes and 3D Model

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1438,7 +1438,8 @@
                 { result: { name: 'pá_ferro', quantity: 1 }, ingredients: [{ name: 'barra_ferro', quantity: 1 }, { name: 'galho', quantity: 1 }] }
             ],
             pestle: [
-                { result: { name: 'oleo_vegetal', quantity: 1 }, ingredients: [{ name: 'muda_arvore', quantity: 1 }, { name: 'pote_barro', quantity: 1 }] }
+                { result: { name: 'oleo_vegetal', quantity: 1 }, ingredients: [{ name: 'semente_macieira', quantity: 1 }, { name: 'pote_barro', quantity: 1 }] },
+                { result: { name: 'oleo_vegetal', quantity: 1 }, ingredients: [{ name: 'pinhão', quantity: 1 }, { name: 'pote_barro', quantity: 1 }] }
             ],
             workbench: [
                 { result: { name: 'pilao', quantity: 1 }, ingredients: [{ name: 'bloco_madeira', quantity: 1 }] },
@@ -4923,10 +4924,18 @@
                 const group = new THREE.Group();
                 const woodMat = new THREE.MeshStandardMaterial({ color: 0x8B4513 });
 
-                // Bowl
-                const bowlGeom = new THREE.CylinderGeometry(0.2, 0.15, 0.3, 16);
+                // Bowl (Hollowed using LatheGeometry)
+                const bowlPoints = [
+                    new THREE.Vector2(0, -0.15),
+                    new THREE.Vector2(0.15, -0.15),
+                    new THREE.Vector2(0.2, 0.15),
+                    new THREE.Vector2(0.17, 0.15),
+                    new THREE.Vector2(0.12, -0.05),
+                    new THREE.Vector2(0, -0.05)
+                ];
+                const bowlGeom = new THREE.LatheGeometry(bowlPoints, 16);
                 const bowl = new THREE.Mesh(bowlGeom, woodMat);
-                bowl.position.y = -0.1;
+                bowl.position.y = 0;
                 bowl.castShadow = true;
                 bowl.receiveShadow = true;
                 group.add(bowl);
@@ -9504,9 +9513,17 @@
                             const group = new THREE.Group();
                             const woodMat = ghostBlockMaterial;
 
-                            const bowlGeom = new THREE.CylinderGeometry(0.2, 0.15, 0.3, 16);
+                            const bowlPoints = [
+                                new THREE.Vector2(0, -0.15),
+                                new THREE.Vector2(0.15, -0.15),
+                                new THREE.Vector2(0.2, 0.15),
+                                new THREE.Vector2(0.17, 0.15),
+                                new THREE.Vector2(0.12, -0.05),
+                                new THREE.Vector2(0, -0.05)
+                            ];
+                            const bowlGeom = new THREE.LatheGeometry(bowlPoints, 16);
                             const bowl = new THREE.Mesh(bowlGeom, woodMat);
-                            bowl.position.y = -0.1;
+                            bowl.position.y = 0;
                             group.add(bowl);
 
                             const pestleStickGeom = new THREE.CylinderGeometry(0.04, 0.04, 0.4, 8);


### PR DESCRIPTION
This change updates the crafting logic for Vegetable Oil in the Pilão (pestle) and improves its visual representation.

Crafting Changes:
- Removed recipe: 1 Tree Sapling + 1 Clay Pot -> Vegetable Oil
- Added recipe: 1 Apple Seed + 1 Clay Pot -> Vegetable Oil
- Added recipe: 1 Pine Nut + 1 Clay Pot -> Vegetable Oil

Visual Changes:
- Replaced the solid cylindrical model of the Pilão with a hollowed-out bowl design using THREE.LatheGeometry. The new profile includes a base, an outer wall, a top rim, and an inner cavity.
- Updated both the permanent placed object and the placement preview (ghost) to use the new hollow design.

---
*PR created automatically by Jules for task [6116471201176745036](https://jules.google.com/task/6116471201176745036) started by @Armandodecampos*