### PR TITLE
Implement hunger system and eating mechanics

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -701,6 +701,7 @@
         }
         #healthBarFill { background-color: #ff4444; }
         #breathBarFill { background-color: #4444ff; }
+        #hungerBarFill { background-color: #ff9800; }
         .bar-text {
             position: absolute;
             width: 100%;
@@ -987,6 +988,10 @@
             <div id="breathBarFill" class="bar-fill"></div>
             <div class="bar-text">FOLEGO</div>
         </div>
+        <div class="bar-container">
+            <div id="hungerBarFill" class="bar-fill"></div>
+            <div class="bar-text">FOME</div>
+        </div>
     </div>
 
     <div id="faintedOverlay">
@@ -1108,8 +1113,10 @@
         let playerBody;
         let playerHealth = 100, playerMaxHealth = 100;
         let playerBreath = 100, playerMaxBreath = 100;
+        let playerHunger = 100, playerMaxHunger = 100;
+        let hungerDecayRate = 0.5;
         let isFainted = false;
-        let healthBarFill, breathBarFill, faintedOverlay, statBars;
+        let healthBarFill, breathBarFill, hungerBarFill, faintedOverlay, statBars;
 
         let islandBody; // Corpo de física para o terreno (agora uma ilha)
         let raftBodies = []; // NOVO: Array para armazenar corpos das jangadas
@@ -2803,6 +2810,17 @@
             if (typeof updateFloatingItem === 'function') {
                 updateFloatingItem();
             }
+        }
+
+        function eatItem(item, index) {
+            if (!item) return;
+            playerHunger = Math.min(playerMaxHunger, playerHunger + 20);
+            item.quantity--;
+            if (item.quantity <= 0) {
+                beltItems[index] = null;
+            }
+            addNotification(`Você comeu ${itemDisplayNames[item.name] || item.name}`);
+            updateUI();
         }
 
         function createMound(intersect, isPositive = false, itemType = null) {
@@ -6314,6 +6332,7 @@
             interactionHintElement = document.getElementById('interactionHint');
             healthBarFill = document.getElementById('healthBarFill');
             breathBarFill = document.getElementById('breathBarFill');
+            hungerBarFill = document.getElementById('hungerBarFill');
             faintedOverlay = document.getElementById('faintedOverlay');
             statBars = document.getElementById('statBars');
 
@@ -6808,10 +6827,17 @@
                         }
                     }
 
-                    const primaryActionType = getActionType(beltItems[selectedSlotIndex]);
+                    const heldItem = beltItems[selectedSlotIndex];
+                    const primaryActionType = getActionType(heldItem);
                     if (primaryActionType === 'place') {
-                        placeBlock(beltItems[selectedSlotIndex], selectedSlotIndex);
-                        blockPlacedThisClick = true; // Marca que colocamos algo
+                        // Se for comida, prioriza comer a menos que esteja agachado (para plantar)
+                        if (heldItem && (heldItem.name === appleItemName || heldItem.name === coconutItemName) && !isCrouching) {
+                            eatItem(heldItem, selectedSlotIndex);
+                            blockPlacedThisClick = true;
+                        } else {
+                            placeBlock(heldItem, selectedSlotIndex);
+                            blockPlacedThisClick = true; // Marca que colocamos algo
+                        }
                     } else {
                         isAttemptingToDestroy = true; // NOVO: Define a intenção
                         startDestruction();
@@ -7891,6 +7917,7 @@
         function respawnPlayer() {
             playerHealth = playerMaxHealth;
             playerBreath = playerMaxBreath;
+            playerHunger = playerMaxHunger;
 
             // Reset position to island center
             if (playerBody) {
@@ -10407,13 +10434,18 @@
                 }
                 playerHealth = Math.max(0, Math.min(playerMaxHealth, playerHealth));
 
-                if (playerHealth <= 0) {
+                // Hunger decay
+                playerHunger -= delta * hungerDecayRate;
+                playerHunger = Math.max(0, Math.min(playerMaxHunger, playerHunger));
+
+                if (playerHealth <= 0 || playerHunger <= 0) {
                     faintPlayer();
                 }
 
                 // Atualiza UI das barras
                 if (healthBarFill) healthBarFill.style.width = `${(playerHealth / playerMaxHealth) * 100}%`;
                 if (breathBarFill) breathBarFill.style.width = `${(playerBreath / playerMaxBreath) * 100}%`;
+                if (hungerBarFill) hungerBarFill.style.width = `${(playerHunger / playerMaxHunger) * 100}%`;
             }
 
             // Atualiza o tempo para as ondas da água
@@ -10539,12 +10571,16 @@
             window.activeCampfires = activeCampfires;
             Object.defineProperty(window, 'playerHealth', { get: () => playerHealth, set: (v) => { playerHealth = v; } });
             Object.defineProperty(window, 'playerBreath', { get: () => playerBreath, set: (v) => { playerBreath = v; } });
+            Object.defineProperty(window, 'playerHunger', { get: () => playerHunger, set: (v) => { playerHunger = v; } });
+            Object.defineProperty(window, 'hungerDecayRate', { get: () => hungerDecayRate, set: (v) => { hungerDecayRate = v; } });
+            Object.defineProperty(window, 'isCrouching', { get: () => isCrouching, set: (v) => { isCrouching = v; } });
             Object.defineProperty(window, 'isFainted', { get: () => isFainted, set: (v) => { isFainted = v; } });
             Object.defineProperty(window, 'openedChest', { get: () => openedChest, set: (v) => { openedChest = v; } });
             window.heldTorchGroup = heldTorchGroup;
             Object.defineProperty(window, 'isJumpBoosting', { get: () => isJumpBoosting, set: (v) => { isJumpBoosting = v; } });
             window.faintPlayer = faintPlayer;
             window.respawnPlayer = respawnPlayer;
+            window.eatItem = eatItem;
             Object.defineProperty(window, 'renderDistance', {
                 get: () => renderDistance,
                 set: (v) => { renderDistance = v; }

--- a/tests/hunger.spec.js
+++ b/tests/hunger.spec.js
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+
+test('hunger decreases over time', async ({ page }) => {
+  test.setTimeout(120000);
+  await page.goto('http://localhost:8080/index.htm');
+  await page.waitForSelector('#startButton', { state: 'visible' });
+  await page.click('#startButton');
+
+  // Wait for world to be ready
+  await page.waitForFunction(() => window.isWorldReady === true, { timeout: 90000 });
+
+  const initialHunger = await page.evaluate(() => window.playerHunger);
+  expect(initialHunger).toBeLessThanOrEqual(100);
+
+  // Wait for some time to allow hunger to decay
+  await page.waitForTimeout(5000);
+
+  const hunger = await page.evaluate(() => window.playerHunger);
+  expect(hunger).toBeLessThan(initialHunger);
+});
+
+test('eating food restores hunger', async ({ page }) => {
+  test.setTimeout(120000);
+  await page.goto('http://localhost:8080/index.htm');
+  await page.waitForSelector('#startButton', { state: 'visible' });
+  await page.click('#startButton');
+
+  // Wait for world to be ready
+  await page.waitForFunction(() => window.isWorldReady === true, { timeout: 90000 });
+
+  // Manually set hunger low and pause decay for a moment
+  await page.evaluate(() => {
+    window.playerHunger = 50;
+    window._originalDecay = window.hungerDecayRate;
+    window.hungerDecayRate = 0;
+  });
+
+  // Give the player an apple
+  await page.evaluate(() => {
+    window.beltItems[1] = { name: 'maca', quantity: 1 };
+    window.updateUI();
+  });
+
+  // Select the apple slot (index 1 is key '2')
+  await page.keyboard.press('2');
+
+  // Direct call to eatItem to bypass UI/event issues in test
+  await page.evaluate(() => {
+    window.eatItem(window.beltItems[window.selectedSlotIndex], window.selectedSlotIndex);
+  });
+
+  const hunger = await page.evaluate(() => window.playerHunger);
+  expect(hunger).toBeCloseTo(70, 0);
+
+  // Restore decay
+  await page.evaluate(() => {
+    window.hungerDecayRate = window._originalDecay;
+  });
+});
+
+test('hunger reaching zero causes fainting', async ({ page }) => {
+  test.setTimeout(120000);
+  await page.goto('http://localhost:8080/index.htm');
+  await page.waitForSelector('#startButton', { state: 'visible' });
+  await page.click('#startButton');
+
+  // Wait for world to be ready
+  await page.waitForFunction(() => window.isWorldReady === true, { timeout: 90000 });
+
+  // Manually set hunger very low and increase decay rate
+  await page.evaluate(() => {
+    window.playerHunger = 1;
+    window.hungerDecayRate = 10;
+  });
+
+  // Wait for fainted overlay to be displayed
+  await page.waitForFunction(() => {
+    const overlay = document.getElementById('faintedOverlay');
+    return overlay && window.getComputedStyle(overlay).display !== 'none';
+  }, { timeout: 30000 });
+
+  const isFainted = await page.evaluate(() => window.isFainted);
+  expect(isFainted).toBe(true);
+});


### PR DESCRIPTION
This PR introduces a new hunger system to the game.

Key changes:
- **HUD Update**: A new orange hunger bar has been added to the status bars in the bottom right corner.
- **Hunger Decay**: Player hunger now decreases at a rate of 0.5 units per second.
- **Penalty**: If hunger reaches 0, the player will faint, triggering the existing faint and respawn sequence.
- **Eating Mechanics**:
  - Players can now consume apples and coconuts by left-clicking while holding them.
  - Each fruit restores 20 units of hunger, capped at 100.
  - To allow planting/placing these items instead of eating them, the player must be crouching (C key).
- **Technical**:
  - New variables `playerHunger`, `playerMaxHunger`, and `hungerDecayRate` manage the system state.
  - A new `eatItem` function handles consumption and inventory updates.
  - Stat variables are exposed to `window` for compatibility with the automated test suite.
- **Testing**:
  - A new test file `tests/hunger.spec.js` has been added to verify decay, eating, and fainting logic.
  - Visual verification was performed using Playwright screenshots.

---
*PR created automatically by Jules for task [18365075063869402747](https://jules.google.com/task/18365075063869402747) started by @Armandodecampos*