### PR TITLE
feat: implement hunger system with low hunger visual and physical eff…

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -994,6 +994,9 @@
         </div>
     </div>
 
+    <div id="hungerOverlay" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: black; opacity: 0; pointer-events: none; z-index: 9000;"></div>
+    <div id="hungerWarning" style="position: absolute; top: 20%; left: 50%; transform: translateX(-50%); color: #ff0000; font-size: 2em; font-weight: bold; text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8); z-index: 9001; display: none; pointer-events: none;">Você está muito faminto</div>
+
     <div id="faintedOverlay">
         <p>Você desmaiou...</p>
     </div>
@@ -1114,9 +1117,9 @@
         let playerHealth = 100, playerMaxHealth = 100;
         let playerBreath = 100, playerMaxBreath = 100;
         let playerHunger = 100, playerMaxHunger = 100;
-        let hungerDecayRate = 0.5;
+        let hungerDecayRate = 0.05;
         let isFainted = false;
-        let healthBarFill, breathBarFill, hungerBarFill, faintedOverlay, statBars;
+        let healthBarFill, breathBarFill, hungerBarFill, hungerOverlay, hungerWarning, faintedOverlay, statBars;
 
         let islandBody; // Corpo de física para o terreno (agora uma ilha)
         let raftBodies = []; // NOVO: Array para armazenar corpos das jangadas
@@ -6333,6 +6336,8 @@
             healthBarFill = document.getElementById('healthBarFill');
             breathBarFill = document.getElementById('breathBarFill');
             hungerBarFill = document.getElementById('hungerBarFill');
+            hungerOverlay = document.getElementById('hungerOverlay');
+            hungerWarning = document.getElementById('hungerWarning');
             faintedOverlay = document.getElementById('faintedOverlay');
             statBars = document.getElementById('statBars');
 
@@ -6882,7 +6887,7 @@
                 // O martelo foi removido temporariamente das ferramentas de destruição
                 if (item.name === axeItemName || item.name === pickaxeItemName || item.name === shovelItemName || item.name === ironAxeItemName || item.name === ironPickaxeItemName || item.name === ironShovelItemName || item.name === branchItemName || item.name === dirtItemName || item.name === sandItemName) return 'destroy';
                 // Itens de colocação
-                if (item.name === cobItemName || item.name === floorItemName || item.name === treeSaplingItemName || item.name === appleSeedItemName || item.name === pineSeedItemName || item.name === coconutItemName || item.name === woodenPlankItemName || item.name === treeTrunkItemName || item.name === boxItemName || item.name === basketItemName || item.name === raftItemName || item.name === stoneBlockItemName || item.name === woodenBlockItemName || item.name === stoneFloorItemName || item.name === woodenFloorItemName || item.name === stoneItemName || item.name === campfireItemName || item.name === torchItemName || item.name === workbenchItemName || item.name === mesaItemName || item.name === bigornaItemName || item.name === furnaceItemName || item.name === pestleItemName) return 'place';
+                if (item.name === cobItemName || item.name === floorItemName || item.name === treeSaplingItemName || item.name === appleItemName || item.name === appleSeedItemName || item.name === pineSeedItemName || item.name === coconutItemName || item.name === woodenPlankItemName || item.name === treeTrunkItemName || item.name === boxItemName || item.name === basketItemName || item.name === raftItemName || item.name === stoneBlockItemName || item.name === woodenBlockItemName || item.name === stoneFloorItemName || item.name === woodenFloorItemName || item.name === stoneItemName || item.name === campfireItemName || item.name === torchItemName || item.name === workbenchItemName || item.name === mesaItemName || item.name === bigornaItemName || item.name === furnaceItemName || item.name === pestleItemName) return 'place';
                 return null; // Retorna nulo se o item não tiver um tipo de ação conhecido
             }
 
@@ -7926,6 +7931,8 @@
             }
 
             if (faintedOverlay) faintedOverlay.style.display = 'none';
+            if (hungerOverlay) hungerOverlay.style.opacity = 0;
+            if (hungerWarning) hungerWarning.style.display = 'none';
             isFainted = false;
         }
 
@@ -8536,6 +8543,12 @@
             }
             if (isCrouching) {
                 currentMoveSpeed *= crouchSpeedMultiplier;
+            }
+
+            // Low hunger speed penalty (below 10%)
+            if (playerHunger < playerMaxHunger * 0.1) {
+                const hungerFactor = playerHunger / (playerMaxHunger * 0.1);
+                currentMoveSpeed *= (0.5 + 0.5 * hungerFactor); // Gradual reduction to 50% speed
             }
 
             const forward = new THREE.Vector3();
@@ -10446,6 +10459,16 @@
                 if (healthBarFill) healthBarFill.style.width = `${(playerHealth / playerMaxHealth) * 100}%`;
                 if (breathBarFill) breathBarFill.style.width = `${(playerBreath / playerMaxBreath) * 100}%`;
                 if (hungerBarFill) hungerBarFill.style.width = `${(playerHunger / playerMaxHunger) * 100}%`;
+
+                // Hunger effects (below 10%)
+                if (playerHunger < playerMaxHunger * 0.1) {
+                    const hungerRatio = playerHunger / (playerMaxHunger * 0.1); // 1.0 at 10% to 0.0 at 0%
+                    if (hungerOverlay) hungerOverlay.style.opacity = (1.0 - hungerRatio) * 0.8;
+                    if (hungerWarning) hungerWarning.style.display = 'block';
+                } else {
+                    if (hungerOverlay) hungerOverlay.style.opacity = 0;
+                    if (hungerWarning) hungerWarning.style.display = 'none';
+                }
             }
 
             // Atualiza o tempo para as ondas da água


### PR DESCRIPTION
…ects

- Added hunger bar (orange) to HUD.
- Implemented time-based hunger decay (0.05 units/sec).
- Added food items ('maca' and 'coco') which restore 20 hunger units.
- Resolved conflict between eating and planting: holding food now eats it unless crouching.
- Added visual darkening effect and "Você está muito faminto" warning when hunger is below 10%.
- Implemented gradual movement speed penalty (up to 50%) during low hunger.
- Player faints and respawns when hunger reaches zero.
- Added Playwright tests for hunger decay, eating, and fainting logic.