### PR TITLE
feat: implement hunger system and HUD status icons

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -685,6 +685,17 @@
             pointer-events: none;
             display: none; /* Hidden until game starts */
         }
+        .stat-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .stat-icon {
+            width: 24px;
+            text-align: center;
+            font-size: 18px;
+            text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
+        }
         .bar-container {
             width: 200px;
             height: 20px;
@@ -980,17 +991,26 @@
     </div>
 
     <div id="statBars">
-        <div class="bar-container">
-            <div id="healthBarFill" class="bar-fill"></div>
-            <div class="bar-text">VIDA</div>
+        <div class="stat-row">
+            <i class="fas fa-heart stat-icon" style="color: #ff4444;"></i>
+            <div class="bar-container">
+                <div id="healthBarFill" class="bar-fill"></div>
+                <div class="bar-text">VIDA</div>
+            </div>
         </div>
-        <div class="bar-container">
-            <div id="breathBarFill" class="bar-fill"></div>
-            <div class="bar-text">FOLEGO</div>
+        <div class="stat-row">
+            <i class="fas fa-bolt stat-icon" style="color: #4444ff;"></i>
+            <div class="bar-container">
+                <div id="breathBarFill" class="bar-fill"></div>
+                <div class="bar-text">FOLEGO</div>
+            </div>
         </div>
-        <div class="bar-container">
-            <div id="hungerBarFill" class="bar-fill"></div>
-            <div class="bar-text">FOME</div>
+        <div class="stat-row">
+            <i class="fas fa-utensils stat-icon" style="color: #ff9800;"></i>
+            <div class="bar-container">
+                <div id="hungerBarFill" class="bar-fill"></div>
+                <div class="bar-text">FOME</div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
- Added hunger bar (orange) to HUD with a utensils icon.
- Added heart icon for health bar and bolt icon for energy/breath bar.
- Implemented time-based hunger decay (0.05 units/sec).
- Added food items ('maca' and 'coco') which restore 20 hunger units.
- Resolved interaction conflict: holding food now eats it unless crouching.
- Added visual darkening effect and "Você está muito faminto" warning when hunger is below 10%.
- Implemented gradual movement speed penalty (up to 50%) during low hunger.
- Player faints and respawns when hunger reaches zero.
- Added Playwright tests for hunger decay, eating, and fainting logic.
- Updated HUD layout to align icons horizontally with stat bars.