### PR TITLE
feat: implement hunger system with HUD icons and low hunger effects

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -999,7 +999,7 @@
             </div>
         </div>
         <div class="stat-row">
-            <i class="fas fa-bolt stat-icon" style="color: #4444ff;"></i>
+            <i class="fas fa-wind stat-icon" style="color: #4444ff;"></i>
             <div class="bar-container">
                 <div id="breathBarFill" class="bar-fill"></div>
                 <div class="bar-text">FOLEGO</div>
@@ -1137,7 +1137,7 @@
         let playerHealth = 100, playerMaxHealth = 100;
         let playerBreath = 100, playerMaxBreath = 100;
         let playerHunger = 100, playerMaxHunger = 100;
-        let hungerDecayRate = 0.05;
+        let hungerDecayRate = 0.1;
         let isFainted = false;
         let healthBarFill, breathBarFill, hungerBarFill, hungerOverlay, hungerWarning, faintedOverlay, statBars;
 


### PR DESCRIPTION
- Added hunger bar (orange) to HUD with a utensils icon.
- Added heart icon for health bar and wind icon for breath bar.
- Implemented hunger decay (0.1 units/sec).
- Enabled eating apples ('maca') and coconuts ('coco') to restore hunger.
- Prioritized eating action over planting for food items (crouch to plant).
- Added visual darkening and movement speed penalties for hunger < 10%.
- Implemented fainting and respawning logic for 0 hunger.
- Added Playwright tests for hunger system verification.