### PR TITLE
Improve Exhaustion Blinking and HUD Visibility

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -43,7 +43,7 @@
             font-size: 1.2em;
             font-weight: bold;
             text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
-            z-index: 2000;
+            z-index: 9800;
             display: none;
             text-align: center;
             pointer-events: none;
@@ -61,7 +61,7 @@
             align-items: flex-end;
             gap: 10px;
             pointer-events: none;
-            z-index: 3000;
+            z-index: 9800;
         }
 
         .acquisition-notification {
@@ -103,7 +103,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            z-index: 999; /* Ensure it's above the canvas, but below the messageBox */
+            z-index: 9800; /* Ensure it's above the canvas, but below the messageBox */
         }
         #crosshair::before, #crosshair::after { /* Create crosshair lines */
             content: '';
@@ -130,7 +130,7 @@
             font-weight: bold;
             text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
             pointer-events: none;
-            z-index: 1000;
+            z-index: 9800;
             display: none;
             text-align: center;
             white-space: pre-wrap;
@@ -277,7 +277,7 @@
             background-color: transparent; /* Fundo transparente */
             padding: 10px;
             border-radius: 10px;
-            z-index: 998;
+            z-index: 9800;
             visibility: hidden;
             opacity: 0;
             transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
@@ -541,7 +541,7 @@
             background-color: rgba(0, 0, 0, 0.5);
             border: 2px solid rgba(255, 255, 255, 0.8);
             border-radius: 50%;
-            z-index: 1000;
+            z-index: 9800;
             display: none; /* Inicia oculto, aparece no startGame */
         }
         #clockFace {
@@ -591,7 +591,7 @@
             font-size: 14px;
             font-weight: bold;
             text-shadow: 1px 1px 2px black;
-            z-index: 1000;
+            z-index: 9800;
             pointer-events: none;
             display: none; /* Hidden by default */
         }
@@ -681,7 +681,7 @@
             display: flex;
             flex-direction: column;
             gap: 10px;
-            z-index: 1000;
+            z-index: 9800;
             pointer-events: none;
             display: none; /* Hidden until game starts */
         }
@@ -848,6 +848,7 @@
     </style>
 </head>
 <body>
+    <div id="sleepOverlay" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: black; opacity: 0; pointer-events: none; z-index: 9500;"></div>
     <div id="tooltip"></div>
     <div id="startScreen">
         <h1>Small World</h1>
@@ -858,7 +859,7 @@
     </div>
 
     <!-- Novo botão de menu no canto superior esquerdo -->
-    <div id="hudButtons" class="fixed top-4 left-4 flex gap-2 z-[1000] hidden">
+    <div id="hudButtons" class="fixed top-4 left-4 flex gap-2 z-[9800] hidden">
         <button id="menuIconButton" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg shadow-lg flex items-center space-x-2">
             <i class="fas fa-cog"></i> <!-- Ícone de engrenagem -->
             <span>Esc</span>
@@ -987,7 +988,7 @@
     <div id="notification"></div>
     <div id="acquisition-container"></div>
 
-    <div id="weightDisplay" class="absolute bottom-5 left-5 bg-black/50 text-white px-3 py-1.5 rounded-lg z-[998] text-base font-bold border border-white/20 hidden">
+    <div id="weightDisplay" class="absolute bottom-5 left-5 bg-black/50 text-white px-3 py-1.5 rounded-lg z-[9800] text-base font-bold border border-white/20 hidden">
         Peso: 0.0 kg / 500 kg
     </div>
 
@@ -1025,7 +1026,6 @@
     <div id="hungerOverlay" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: black; opacity: 0; pointer-events: none; z-index: 9000;"></div>
     <div id="hungerWarning" style="position: absolute; top: 20%; left: 50%; transform: translateX(-50%); color: #ff0000; font-size: 2em; font-weight: bold; text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8); z-index: 9001; display: none; pointer-events: none;">Você está muito faminto</div>
 
-    <div id="sleepOverlay" style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: black; opacity: 0; pointer-events: none; z-index: 9500;"></div>
     <div id="exhaustedWarning" style="position: absolute; top: 25%; left: 50%; transform: translateX(-50%); color: #ffff00; font-size: 2em; font-weight: bold; text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8); z-index: 9600; display: none; pointer-events: none;">Você está exausto</div>
 
     <div id="faintedOverlay">
@@ -10617,7 +10617,7 @@
                     if (exhaustedWarning) exhaustedWarning.style.display = 'block';
 
                     const energyFactor = playerEnergy / (playerMaxEnergy * 0.1); // 1.0 at 10%, 0.0 at 0%
-                    const cycle = 0.5 + 2.0 * energyFactor;
+                    const cycle = 4.0 - 2.0 * energyFactor;
                     const blackDuration = cycle * (0.8 - 0.6 * energyFactor);
 
                     blinkTimer += delta;


### PR DESCRIPTION
This PR addresses the request to make the screen blink more slowly and for longer durations as player energy decreases below 10%, simulating the character struggling to stay awake. It also ensures that the game HUD remains visible even when the screen is blacked out.

Key changes:
1. **Blinking Logic:** In `index.htm`, the `cycle` formula was updated from `0.5 + 2.0 * energyFactor` (which sped up as energy dropped) to `4.0 - 2.0 * energyFactor`. This results in a 2-second cycle at 10% energy and a 4-second cycle at 0% energy.
2. **HUD Visibility:** The `z-index` of all critical HUD elements was increased to `9800`. Since the `sleepOverlay` (which creates the black screen) is at `9500`, the HUD now correctly sits on top of it.
3. **DOM Structure:** The `sleepOverlay` was moved to the top of the `<body>` to ensure it doesn't accidentally cover other elements due to nesting and stacking context issues.
4. **Verification:** Successfull visual verification was performed using Playwright, and core regression tests for hunger and movement passed.

---
*PR created automatically by Jules for task [15180425243348990777](https://jules.google.com/task/15180425243348990777) started by @Armandodecampos*