### PR TITLE
Add Sleeping Mat and Bed with Energy Recovery Scaling

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1457,61 +1457,6 @@
         let openedChest = null; // Guarda a referência para os dados do contêiner aberto
         let craftingModal, recipesContainer, craftingTitle, closeCraftingButton;
 
-        const recipes = {
-            initial: [
-                { result: { name: 'machado', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 1 }, { name: 'corda', quantity: 1 }, { name: 'galho', quantity: 1 }] },
-                { result: { name: 'martelo', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 1 }, { name: 'corda', quantity: 1 }, { name: 'galho', quantity: 1 }] },
-                { result: { name: 'picareta', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 1 }, { name: 'corda', quantity: 1 }, { name: 'galho', quantity: 1 }] },
-                { result: { name: 'pá', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 1 }, { name: 'corda', quantity: 1 }, { name: 'galho', quantity: 1 }] },
-                { result: { name: 'cob', quantity: 20 }, ingredients: [{ name: 'terra', quantity: 1 }, { name: 'areia', quantity: 1 }, { name: 'capim', quantity: 20 }] },
-                { result: { name: 'piso', quantity: 60 }, ingredients: [{ name: 'terra', quantity: 1 }, { name: 'areia', quantity: 1 }, { name: 'capim', quantity: 20 }] },
-                { result: { name: 'jangada', quantity: 1 }, ingredients: [{ name: 'tronco_arvore', quantity: 10 }, { name: 'corda', quantity: 50 }, { name: 'tecido', quantity: 20 }] },
-                { result: { name: 'tocha', quantity: 1 }, ingredients: [{ name: 'galho', quantity: 1 }, { name: 'tecido', quantity: 5 }, { name: 'corda', quantity: 1 }, { name: 'oleo_vegetal', quantity: 1 }] },
-                { result: { name: 'fogueira', quantity: 1 }, ingredients: [{ name: 'galho', quantity: 3 }, { name: 'oleo_vegetal', quantity: 1 }] },
-                { result: { name: 'forno', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 10 }, { name: 'areia', quantity: 1 }, { name: 'terra', quantity: 1 }, { name: 'fogueira', quantity: 1 }] },
-                { result: { name: 'bancada_trabalho', quantity: 1 }, ingredients: [{ name: 'tronco_arvore', quantity: 10 }, { name: 'kit_ferramentas_bancada', quantity: 1 }] },
-                { result: { name: 'corda', quantity: 1 }, ingredients: [{ name: 'capim', quantity: 5 }] },
-                { result: { name: 'cesto_capim', quantity: 1 }, ingredients: [{ name: 'capim', quantity: 15 }, { name: 'corda', quantity: 1 }] }
-            ],
-            furnace: [
-                { result: { name: 'pote_barro', quantity: 20 }, ingredients: [{ name: 'terra', quantity: 1 }, { name: 'areia', quantity: 1 }] },
-                { result: { name: 'barra_ferro', quantity: 1 }, ingredients: [{ name: 'minerio_ferro', quantity: 1 }] },
-                { result: { name: 'bigorna', quantity: 1 }, ingredients: [{ name: 'minerio_ferro', quantity: 10 }] },
-                { result: { name: 'kit_ferramentas_bancada', quantity: 1 }, ingredients: [{ name: 'barra_ferro', quantity: 20 }] }
-            ],
-            anvil: [
-                { result: { name: 'machado_ferro', quantity: 1 }, ingredients: [{ name: 'barra_ferro', quantity: 1 }, { name: 'galho', quantity: 1 }] },
-                { result: { name: 'martelo_ferro', quantity: 1 }, ingredients: [{ name: 'barra_ferro', quantity: 1 }, { name: 'galho', quantity: 1 }] },
-                { result: { name: 'picareta_ferro', quantity: 1 }, ingredients: [{ name: 'barra_ferro', quantity: 1 }, { name: 'galho', quantity: 1 }] },
-                { result: { name: 'pá_ferro', quantity: 1 }, ingredients: [{ name: 'barra_ferro', quantity: 1 }, { name: 'galho', quantity: 1 }] }
-            ],
-            pestle: [
-                { result: { name: 'oleo_vegetal', quantity: 1 }, ingredients: [{ name: 'semente_macieira', quantity: 1 }, { name: 'pote_barro', quantity: 1 }] },
-                { result: { name: 'oleo_vegetal', quantity: 1 }, ingredients: [{ name: 'pinhão', quantity: 1 }, { name: 'pote_barro', quantity: 1 }] }
-            ],
-            workbench: [
-                { result: { name: 'pilao', quantity: 1 }, ingredients: [{ name: 'bloco_madeira', quantity: 1 }] },
-                { result: { name: 'caixote', quantity: 1 }, ingredients: [{ name: 'bloco_madeira', quantity: 20 }] },
-                { result: { name: 'tecido', quantity: 1 }, ingredients: [{ name: 'capim', quantity: 5 }] },
-                { result: { name: 'bloco_pedra', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 1 }] },
-                { result: { name: 'bloco_madeira', quantity: 4 }, ingredients: [{ name: 'tronco_arvore', quantity: 1 }] },
-                { result: { name: 'piso_madeira', quantity: 5 }, ingredients: [{ name: 'bloco_madeira', quantity: 1 }] },
-                { result: { name: 'piso_pedra', quantity: 5 }, ingredients: [{ name: 'pedra', quantity: 1 }] }
-            ]
-        };
-
-        // Inventário (agora separado para cinto e mochila)
-        let beltItems = new Array(numBeltSlots).fill(null);
-        let backpackItems = [null];
-        window.backpackItems = backpackItems;
-
-        // Click and move variables
-        let selectedItem = null; // { item: { name, quantity }, sourceLocation: 'belt' | 'backpack' | 'chest', sourceIndex: number }
-
-        // Variáveis para divisão de itens
-        let splitModal, splitInput, confirmSplitBtn, cancelSplitBtn, splitMaxText;
-        let pendingSplitData = null; // { item, index, containerType }
-
         // NOVO: Variável para o elemento da dica de ferramenta
         let tooltipElement;
 
@@ -1524,6 +1469,8 @@
         const pineSeedItemName = 'pinhão';
         const coconutSeedItemName = 'semente_coqueiro';
         const coconutItemName = 'coco';
+        const sleepingMatItemName = 'colchonete';
+        const bedItemName = 'cama';
 
         // NOVO: Variáveis para o sistema de destruição de blocos (Machado e Martelo)
         const axeItemName = 'machado'; // Nome do item de machado no inventário
@@ -1568,6 +1515,63 @@
         const bigornaItemName = 'bigorna';
         const furnaceItemName = 'forno';
 
+        const recipes = {
+            initial: [
+                { result: { name: 'machado', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 1 }, { name: 'corda', quantity: 1 }, { name: 'galho', quantity: 1 }] },
+                { result: { name: 'martelo', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 1 }, { name: 'corda', quantity: 1 }, { name: 'galho', quantity: 1 }] },
+                { result: { name: 'picareta', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 1 }, { name: 'corda', quantity: 1 }, { name: 'galho', quantity: 1 }] },
+                { result: { name: 'pá', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 1 }, { name: 'corda', quantity: 1 }, { name: 'galho', quantity: 1 }] },
+                { result: { name: 'cob', quantity: 20 }, ingredients: [{ name: 'terra', quantity: 1 }, { name: 'areia', quantity: 1 }, { name: 'capim', quantity: 20 }] },
+                { result: { name: 'piso', quantity: 60 }, ingredients: [{ name: 'terra', quantity: 1 }, { name: 'areia', quantity: 1 }, { name: 'capim', quantity: 20 }] },
+                { result: { name: 'jangada', quantity: 1 }, ingredients: [{ name: 'tronco_arvore', quantity: 10 }, { name: 'corda', quantity: 50 }, { name: 'tecido', quantity: 20 }] },
+                { result: { name: 'tocha', quantity: 1 }, ingredients: [{ name: 'galho', quantity: 1 }, { name: 'tecido', quantity: 5 }, { name: 'corda', quantity: 1 }, { name: 'oleo_vegetal', quantity: 1 }] },
+                { result: { name: 'fogueira', quantity: 1 }, ingredients: [{ name: 'galho', quantity: 3 }, { name: 'oleo_vegetal', quantity: 1 }] },
+                { result: { name: 'forno', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 10 }, { name: 'areia', quantity: 1 }, { name: 'terra', quantity: 1 }, { name: 'fogueira', quantity: 1 }] },
+                { result: { name: 'bancada_trabalho', quantity: 1 }, ingredients: [{ name: 'tronco_arvore', quantity: 10 }, { name: 'kit_ferramentas_bancada', quantity: 1 }] },
+                { result: { name: 'corda', quantity: 1 }, ingredients: [{ name: 'capim', quantity: 5 }] },
+                { result: { name: 'cesto_capim', quantity: 1 }, ingredients: [{ name: 'capim', quantity: 15 }, { name: 'corda', quantity: 1 }] },
+                { result: { name: sleepingMatItemName, quantity: 1 }, ingredients: [{ name: fabricItemName, quantity: 10 }, { name: capimItemName, quantity: 50 }, { name: ropeItemName, quantity: 2 }] }
+            ],
+            furnace: [
+                { result: { name: 'pote_barro', quantity: 20 }, ingredients: [{ name: 'terra', quantity: 1 }, { name: 'areia', quantity: 1 }] },
+                { result: { name: 'barra_ferro', quantity: 1 }, ingredients: [{ name: 'minerio_ferro', quantity: 1 }] },
+                { result: { name: 'bigorna', quantity: 1 }, ingredients: [{ name: 'minerio_ferro', quantity: 10 }] },
+                { result: { name: 'kit_ferramentas_bancada', quantity: 1 }, ingredients: [{ name: 'barra_ferro', quantity: 20 }] }
+            ],
+            anvil: [
+                { result: { name: 'machado_ferro', quantity: 1 }, ingredients: [{ name: 'barra_ferro', quantity: 1 }, { name: 'galho', quantity: 1 }] },
+                { result: { name: 'martelo_ferro', quantity: 1 }, ingredients: [{ name: 'barra_ferro', quantity: 1 }, { name: 'galho', quantity: 1 }] },
+                { result: { name: 'picareta_ferro', quantity: 1 }, ingredients: [{ name: 'barra_ferro', quantity: 1 }, { name: 'galho', quantity: 1 }] },
+                { result: { name: 'pá_ferro', quantity: 1 }, ingredients: [{ name: 'barra_ferro', quantity: 1 }, { name: 'galho', quantity: 1 }] }
+            ],
+            pestle: [
+                { result: { name: 'oleo_vegetal', quantity: 1 }, ingredients: [{ name: 'semente_macieira', quantity: 1 }, { name: 'pote_barro', quantity: 1 }] },
+                { result: { name: 'oleo_vegetal', quantity: 1 }, ingredients: [{ name: 'pinhão', quantity: 1 }, { name: 'pote_barro', quantity: 1 }] }
+            ],
+            workbench: [
+                { result: { name: 'pilao', quantity: 1 }, ingredients: [{ name: 'bloco_madeira', quantity: 1 }] },
+                { result: { name: 'caixote', quantity: 1 }, ingredients: [{ name: 'bloco_madeira', quantity: 20 }] },
+                { result: { name: 'tecido', quantity: 1 }, ingredients: [{ name: 'capim', quantity: 5 }] },
+                { result: { name: 'bloco_pedra', quantity: 1 }, ingredients: [{ name: 'pedra', quantity: 1 }] },
+                { result: { name: 'bloco_madeira', quantity: 4 }, ingredients: [{ name: 'tronco_arvore', quantity: 1 }] },
+                { result: { name: 'piso_madeira', quantity: 5 }, ingredients: [{ name: 'bloco_madeira', quantity: 1 }] },
+                { result: { name: 'piso_pedra', quantity: 5 }, ingredients: [{ name: 'pedra', quantity: 1 }] },
+                { result: { name: bedItemName, quantity: 1 }, ingredients: [{ name: woodenBlockItemName, quantity: 10 }, { name: fabricItemName, quantity: 5 }, { name: ropeItemName, quantity: 5 }] }
+            ]
+        };
+
+        // Inventário (agora separado para cinto e mochila)
+        let beltItems = new Array(numBeltSlots).fill(null);
+        let backpackItems = [null];
+        window.backpackItems = backpackItems;
+
+        // Click and move variables
+        let selectedItem = null; // { item: { name, quantity }, sourceLocation: 'belt' | 'backpack' | 'chest', sourceIndex: number }
+
+        // Variáveis para divisão de itens
+        let splitModal, splitInput, confirmSplitBtn, cancelSplitBtn, splitMaxText;
+        let pendingSplitData = null; // { item, index, containerType }
+
         // NOVO: Mapeamento de nomes de itens para exibição
         window.itemDisplayNames = {
             [handItemName]: 'Mão',
@@ -1606,6 +1610,8 @@
             [fabricItemName]: 'Tecido',
             [campfireItemName]: 'Fogueira\nProporciona luz e calor',
             [torchItemName]: 'Tocha\nIlumina o caminho',
+            [sleepingMatItemName]: 'Colchonete\nRecupera 75% de energia',
+            [bedItemName]: 'Cama de Madeira\nRecupera 100% de energia',
             [basketItemName]: 'Cesto de Capim',
             [vegetableOilItemName]: 'Óleo Vegetal',
             [workbenchToolkitItemName]: 'Kit de ferramentas para bancada de trabalho',
@@ -1655,6 +1661,8 @@
             [fabricItemName]: 0.3,
             [campfireItemName]: 2.0,
             [torchItemName]: 0.5,
+            [sleepingMatItemName]: 5.0,
+            [bedItemName]: 15.0,
             [vegetableOilItemName]: 0.5,
             [workbenchToolkitItemName]: 5.0,
             [clayPotItemName]: 2.0,
@@ -2415,6 +2423,8 @@
             if (itemName === fabricItemName) return "https://placehold.co/100x100/FFFFFF/000000?text=Tecido";
             if (itemName === campfireItemName) return "https://placehold.co/100x100/FF4500/FFFFFF?text=Fogueira";
             if (itemName === torchItemName) return "https://placehold.co/100x100/FFA500/FFFFFF?text=Tocha";
+            if (itemName === sleepingMatItemName) return "https://placehold.co/100x100/4169E1/FFFFFF?text=Colchonete";
+            if (itemName === bedItemName) return "https://placehold.co/100x100/8B4513/FFFFFF?text=Cama";
             if (itemName === vegetableOilItemName) return "https://placehold.co/100x100/FFD700/FFFFFF?text=Oleo";
             if (itemName === workbenchToolkitItemName) return "https://placehold.co/100x100/808080/FFFFFF?text=Ferramentas";
             if (itemName === clayPotItemName) return "https://placehold.co/100x100/A0522D/FFFFFF?text=Pote";
@@ -4874,6 +4884,71 @@
                 mesh = group;
                 initialMass = 150;
                 durability = 3.0;
+            } else if (type === sleepingMatItemName) {
+                width = 1.0; height = 0.1; depth = 2.0;
+                blockShape = new CANNON.Box(new CANNON.Vec3(width / 2, height / 2, depth / 2));
+                blockBody.addShape(blockShape);
+
+                const group = new THREE.Group();
+                const matMat = new THREE.MeshStandardMaterial({ color: 0x4169E1 }); // Royal Blue
+                const pillowMat = new THREE.MeshStandardMaterial({ color: 0xFFFFFF });
+
+                const matMesh = new THREE.Mesh(new THREE.BoxGeometry(1.0, 0.1, 2.0), matMat);
+                group.add(matMesh);
+
+                const pillowMesh = new THREE.Mesh(new THREE.BoxGeometry(0.8, 0.15, 0.4), pillowMat);
+                pillowMesh.position.set(0, 0.05, -0.7);
+                group.add(pillowMesh);
+
+                mesh = group;
+                initialMass = 10;
+                durability = 1.0;
+            } else if (type === bedItemName) {
+                width = 1.2; height = 0.6; depth = 2.2;
+                blockShape = new CANNON.Box(new CANNON.Vec3(width / 2, height / 2, depth / 2));
+                blockBody.addShape(blockShape);
+
+                const group = new THREE.Group();
+                const woodMat = new THREE.MeshStandardMaterial({ color: 0x8B4513 });
+                const mattressMat = new THREE.MeshStandardMaterial({ color: 0xFFFFFF });
+                const blanketMat = new THREE.MeshStandardMaterial({ color: 0x8B0000 }); // Dark Red
+
+                // Bed frame base
+                const base = new THREE.Mesh(new THREE.BoxGeometry(1.2, 0.2, 2.2), woodMat);
+                base.position.y = -0.1;
+                group.add(base);
+
+                // Legs
+                const legGeom = new THREE.BoxGeometry(0.1, 0.3, 0.1);
+                [{x: 0.55, z: 1.05}, {x: -0.55, z: 1.05}, {x: 0.55, z: -1.05}, {x: -0.55, z: -1.05}].forEach(pos => {
+                    const leg = new THREE.Mesh(legGeom, woodMat);
+                    leg.position.set(pos.x, -0.35, pos.z);
+                    group.add(leg);
+                });
+
+                // Headboard
+                const headboard = new THREE.Mesh(new THREE.BoxGeometry(1.2, 0.8, 0.1), woodMat);
+                headboard.position.set(0, 0.2, -1.05);
+                group.add(headboard);
+
+                // Mattress
+                const mattress = new THREE.Mesh(new THREE.BoxGeometry(1.1, 0.2, 2.1), mattressMat);
+                mattress.position.y = 0.1;
+                group.add(mattress);
+
+                // Blanket (covering part of the mattress)
+                const blanket = new THREE.Mesh(new THREE.BoxGeometry(1.12, 0.05, 1.4), blanketMat);
+                blanket.position.set(0, 0.2, 0.35);
+                group.add(blanket);
+
+                // Pillow
+                const pillow = new THREE.Mesh(new THREE.BoxGeometry(0.8, 0.15, 0.4), mattressMat);
+                pillow.position.set(0, 0.25, -0.75);
+                group.add(pillow);
+
+                mesh = group;
+                initialMass = 50;
+                durability = 2.0;
             } else if (type === furnaceItemName) {
                 ensureTorchAssets();
                 width = 1.0; height = 1.2; depth = 1.0;
@@ -6483,6 +6558,8 @@
             addItemToInventory(startingChestInventory, { name: basketItemName, quantity: 5 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: workbenchItemName, quantity: 10 }, startingChestMaxWeight, true);
             addItemToInventory(startingChestInventory, { name: mesaItemName, quantity: 10 }, startingChestMaxWeight, true);
+            addItemToInventory(startingChestInventory, { name: sleepingMatItemName, quantity: 2 }, startingChestMaxWeight, true);
+            addItemToInventory(startingChestInventory, { name: bedItemName, quantity: 2 }, startingChestMaxWeight, true);
 
             // Pega o elemento do cinto de inventário e seus slots
             inventoryBeltElement = document.getElementById('inventoryBelt');
@@ -6587,23 +6664,40 @@
                         return;
                     }
 
-                    // Check if looking at ground
+                    // Check if looking at ground, mat or bed
                     raycaster.setFromCamera(new THREE.Vector2(0, 0), camera);
                     const intersects = raycaster.intersectObjects(raycastTargets, true);
-                    let lookingAtGround = false;
+                    let sleepTarget = 'ground';
+                    let canSleep = false;
                     for (const intersect of intersects) {
                         if (intersect.distance > 5) continue;
                         if (islandMeshes.some(m => m.mesh === intersect.object)) {
-                            lookingAtGround = true;
+                            canSleep = true;
+                            sleepTarget = 'ground';
+                            break;
+                        }
+                        let body = null;
+                        let current = intersect.object;
+                        while (current) {
+                            if (current.userData && current.userData.physicsBody) {
+                                body = current.userData.physicsBody;
+                                break;
+                            }
+                            current = current.parent;
+                        }
+                        if (body && (body.userData.type === sleepingMatItemName || body.userData.type === bedItemName)) {
+                            canSleep = true;
+                            sleepTarget = body.userData.type;
                             break;
                         }
                     }
 
-                    if (lookingAtGround) {
+                    if (canSleep) {
                         isSleeping = true;
                         sleepTimer = 0;
+                        playerBody.userData.sleepTarget = sleepTarget;
                     } else {
-                        showNotification("Você precisa olhar para o chão para dormir");
+                        showNotification("Você precisa olhar para o chão, colchonete ou cama para dormir");
                     }
                 }
 
@@ -6967,7 +7061,7 @@
                 // O martelo foi removido temporariamente das ferramentas de destruição
                 if (item.name === axeItemName || item.name === pickaxeItemName || item.name === shovelItemName || item.name === ironAxeItemName || item.name === ironPickaxeItemName || item.name === ironShovelItemName || item.name === branchItemName || item.name === dirtItemName || item.name === sandItemName) return 'destroy';
                 // Itens de colocação
-                if (item.name === cobItemName || item.name === floorItemName || item.name === treeSaplingItemName || item.name === appleItemName || item.name === appleSeedItemName || item.name === pineSeedItemName || item.name === coconutItemName || item.name === woodenPlankItemName || item.name === treeTrunkItemName || item.name === boxItemName || item.name === basketItemName || item.name === raftItemName || item.name === stoneBlockItemName || item.name === woodenBlockItemName || item.name === stoneFloorItemName || item.name === woodenFloorItemName || item.name === stoneItemName || item.name === campfireItemName || item.name === torchItemName || item.name === workbenchItemName || item.name === mesaItemName || item.name === bigornaItemName || item.name === furnaceItemName || item.name === pestleItemName) return 'place';
+                if (item.name === cobItemName || item.name === floorItemName || item.name === treeSaplingItemName || item.name === appleItemName || item.name === appleSeedItemName || item.name === pineSeedItemName || item.name === coconutItemName || item.name === woodenPlankItemName || item.name === treeTrunkItemName || item.name === boxItemName || item.name === basketItemName || item.name === raftItemName || item.name === stoneBlockItemName || item.name === woodenBlockItemName || item.name === stoneFloorItemName || item.name === woodenFloorItemName || item.name === stoneItemName || item.name === campfireItemName || item.name === torchItemName || item.name === workbenchItemName || item.name === mesaItemName || item.name === bigornaItemName || item.name === furnaceItemName || item.name === pestleItemName || item.name === sleepingMatItemName || item.name === bedItemName) return 'place';
                 return null; // Retorna nulo se o item não tiver um tipo de ação conhecido
             }
 
@@ -7357,6 +7451,16 @@
                             playerBody.collisionResponse = false;
                             playerBody.collisionFilterGroup = 0;
                             playerBody.collisionFilterMask = 0;
+                            return true;
+                        }
+                        if (body.userData.type === sleepingMatItemName || body.userData.type === bedItemName) {
+                            if (isSleeping) {
+                                isSleeping = false;
+                                return true;
+                            }
+                            isSleeping = true;
+                            sleepTimer = 0;
+                            playerBody.userData.sleepTarget = body.userData.type;
                             return true;
                         }
                     }
@@ -8682,11 +8786,21 @@
 
                 // Recover energy based on accelerated physics time
                 // 100% in 8 hours (100 game seconds) = 1.0 per game second
-                playerEnergy += physicsDelta * 1.0;
-                if (playerEnergy >= playerMaxEnergy) {
-                    playerEnergy = playerMaxEnergy;
+                let maxRecovery = playerMaxEnergy * 0.5;
+                if (playerBody.userData.sleepTarget === sleepingMatItemName) maxRecovery = playerMaxEnergy * 0.75;
+                else if (playerBody.userData.sleepTarget === bedItemName) maxRecovery = playerMaxEnergy * 1.0;
+
+                if (playerEnergy < maxRecovery) {
+                    playerEnergy += physicsDelta * 1.0;
+                    if (playerEnergy > maxRecovery) playerEnergy = maxRecovery;
+                }
+
+                if (playerEnergy >= maxRecovery) {
                     isSleeping = false;
                     sleepTimer = 0;
+                    if (maxRecovery < playerMaxEnergy) {
+                        showNotification("Você não consegue descansar mais aqui");
+                    }
                 }
 
                 // Stop sleeping if movement keys are pressed
@@ -9677,6 +9791,10 @@
                             group.add(topMesh);
 
                             ghostBlockMesh.add(group);
+                        } else if (currentBlockType === sleepingMatItemName) {
+                            ghostBlockMesh.geometry = new THREE.BoxGeometry(1.0, 0.1, 2.0);
+                        } else if (currentBlockType === bedItemName) {
+                            ghostBlockMesh.geometry = new THREE.BoxGeometry(1.2, 0.6, 2.2);
                         } else if (currentBlockType === pestleItemName) {
                             ghostBlockMesh.geometry = new THREE.BoxGeometry(0, 0, 0);
                             const group = new THREE.Group();
@@ -9709,6 +9827,8 @@
                     // Determina a altura para o cálculo de posicionamento (não muda cada frame, mas precisamos dela)
                     if (currentBlockType === raftItemName) currentGhostHeight = 0.4;
                     else if (currentBlockType === furnaceItemName) currentGhostHeight = 1.2;
+                                else if (currentBlockType === bedItemName) currentGhostHeight = 0.6;
+                                else if (currentBlockType === sleepingMatItemName) currentGhostHeight = 0.1;
                     else if (currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName) currentGhostHeight = 0.85;
                     else if (currentBlockType === 'cob') currentGhostHeight = cobHeight;
                     else if (currentBlockType === 'piso') currentGhostHeight = floorHeight;
@@ -10598,6 +10718,7 @@
                     } else {
                         isSleeping = true;
                         sleepTimer = 0;
+                        playerBody.userData.sleepTarget = 'ground';
                     }
                 }
 
@@ -10758,7 +10879,8 @@
                 inventoryBeltElement.style.opacity = '1';
             }
 
-            isWorldReady = true; window.isWorldReady = true;
+            window.isWorldReady = true;
+            isWorldReady = true;
             window.activeCampfires = activeCampfires;
             Object.defineProperty(window, 'isSleeping', { get: () => isSleeping, set: (v) => { isSleeping = v; } });
             Object.defineProperty(window, 'sleepTimer', { get: () => sleepTimer, set: (v) => { sleepTimer = v; } });


### PR DESCRIPTION
This PR adds a sleeping mat and a wooden bed to the game. 

Key changes:
1.  **New Items:** Added `colchonete` (Sleeping Mat) and `cama` (Bed) constants and metadata (weight, display name, icons).
2.  **3D Models:** Created sophisticated 3D models in `createPlaceableBlock`. The bed includes a frame, headboard, mattress, blanket, and pillow.
3.  **Crafting & Inventory:** Added recipes for both items. They are also available in the starting chest (2 of each).
4.  **Sleeping Mechanics:**
    *   Players can sleep by pressing 'M' while looking at the ground, a mat, or a bed, or by interacting (E) with a placed mat/bed.
    *   Energy regeneration is now capped based on the surface quality: 50% for ground, 75% for mat, and 100% for bed.
    *   Added notifications when the player cannot rest further on a specific surface.
5.  **Fixes:** Reordered item constant declarations to ensure they are available before the `recipes` object is initialized, preventing a runtime error.

Verified with Playwright tests and visual inspection.

---
*PR created automatically by Jules for task [17226028229792186401](https://jules.google.com/task/17226028229792186401) started by @Armandodecampos*