### PR TITLE
Add sleeping mat and bed with specific energy recovery rates

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -6253,6 +6253,7 @@
                 sleepSpeedLimit: 0.01, // Velocidade linear mínima para "acordar"
                 sleepTimeLimit: 1.0 // Tempo mínimo em repouso para "adormecer"
             });
+            playerBody.userData = {}; // Inicializa userData do jogador
             // Posição inicial: centro da esfera em playerRadius + islandSurfaceHeight
             const spawnHeight = getSurfaceHeight(0, 0);
             playerBody.position.set(0, spawnHeight + playerRadius + 2, 0); // Spawns player slightly above the terrain
@@ -7654,6 +7655,7 @@
                     else if (currentBlockType === stoneItemName) materialLoaded = true; // Pedra sempre carregada (usa material básico)
                     else if (currentBlockType === campfireItemName) materialLoaded = true;
                     else if (currentBlockType === torchItemName) materialLoaded = true;
+                    else if (currentBlockType === sleepingMatItemName || currentBlockType === bedItemName) materialLoaded = true;
                     else if (currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName || currentBlockType === furnaceItemName || currentBlockType === pestleItemName) materialLoaded = true;
 
                     if (materialLoaded) {
@@ -10899,6 +10901,7 @@
             window.faintPlayer = faintPlayer;
             window.respawnPlayer = respawnPlayer;
             window.eatItem = eatItem;
+            window.interact = interact;
             Object.defineProperty(window, 'renderDistance', {
                 get: () => renderDistance,
                 set: (v) => { renderDistance = v; }


### PR DESCRIPTION
- Introduced 'colchonete' (sleeping mat) and 'cama' (bed) items.
- Added detailed 3D models for both items in `createPlaceableBlock`.
- Configured crafting recipes and added items to the starting chest.
- Fixed `placeBlock` to allow placing these new items.
- Implemented sleep logic scaling energy recovery based on the surface:
  - Ground/Auto-sleep: 50% recovery.
  - Sleeping Mat: 75% recovery.
  - Bed: 100% recovery.
- Initialized `playerBody.userData` to prevent runtime errors during sleep interaction.
- Fixed item constant declaration order.