### PR TITLE
Update Bed Recipe and Fix Bed/Sleeping Mat Visuals

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1556,7 +1556,7 @@
                 { result: { name: 'bloco_madeira', quantity: 4 }, ingredients: [{ name: 'tronco_arvore', quantity: 1 }] },
                 { result: { name: 'piso_madeira', quantity: 5 }, ingredients: [{ name: 'bloco_madeira', quantity: 1 }] },
                 { result: { name: 'piso_pedra', quantity: 5 }, ingredients: [{ name: 'pedra', quantity: 1 }] },
-                { result: { name: bedItemName, quantity: 1 }, ingredients: [{ name: woodenBlockItemName, quantity: 10 }, { name: fabricItemName, quantity: 5 }, { name: ropeItemName, quantity: 5 }] }
+                { result: { name: bedItemName, quantity: 1 }, ingredients: [{ name: woodenBlockItemName, quantity: 10 }, { name: fabricItemName, quantity: 10 }, { name: capimItemName, quantity: 50 }, { name: ropeItemName, quantity: 2 }] }
             ]
         };
 
@@ -4890,7 +4890,7 @@
                 blockBody.addShape(blockShape);
 
                 const group = new THREE.Group();
-                const matMat = new THREE.MeshStandardMaterial({ color: 0x4169E1 }); // Royal Blue
+                const matMat = new THREE.MeshStandardMaterial({ color: 0x5C4033 }); // Marrom
                 const pillowMat = new THREE.MeshStandardMaterial({ color: 0xFFFFFF });
 
                 const matMesh = new THREE.Mesh(new THREE.BoxGeometry(1.0, 0.1, 2.0), matMat);
@@ -4911,7 +4911,7 @@
                 const group = new THREE.Group();
                 const woodMat = new THREE.MeshStandardMaterial({ color: 0x8B4513 });
                 const mattressMat = new THREE.MeshStandardMaterial({ color: 0xFFFFFF });
-                const blanketMat = new THREE.MeshStandardMaterial({ color: 0x8B0000 }); // Dark Red
+                const blanketMat = new THREE.MeshStandardMaterial({ color: 0x5C4033 }); // Marrom
 
                 // Bed frame base
                 const base = new THREE.Mesh(new THREE.BoxGeometry(1.2, 0.2, 2.2), woodMat);
@@ -4938,7 +4938,7 @@
 
                 // Blanket (covering part of the mattress)
                 const blanket = new THREE.Mesh(new THREE.BoxGeometry(1.12, 0.05, 1.4), blanketMat);
-                blanket.position.set(0, 0.2, 0.35);
+                blanket.position.set(0, 0.226, 0.35);
                 group.add(blanket);
 
                 // Pillow


### PR DESCRIPTION
This change updates the crafting recipe for the bed and improves the visual appearance of both the bed and the sleeping mat. Specifically:
- The bed now requires 10 wooden blocks, 10 fabrics, 50 grass, and 2 ropes.
- The bed's blanket and the sleeping mat's mattress are now brown (0x5C4033).
- A z-fighting issue on the bed was resolved by slightly offsetting the blanket's vertical position.

---
*PR created automatically by Jules for task [18279090830336590633](https://jules.google.com/task/18279090830336590633) started by @Armandodecampos*