### PR TITLE
feat: add craftable and interactive 'Porta' (Door) item

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -4845,8 +4845,8 @@
                 initialMass = initialWoodenFloorMass;
                 durability = woodenFloorDurability;
             } else if (type === doorItemName) {
-                width = 1.0;
-                height = 2.0;
+                width = 1.2; // 3 blocks wide (3 * 0.4)
+                height = 2.4; // 6 blocks high (6 * 0.4)
                 depth = 0.1;
                 // Physics body needs to be offset so the hinge is at the body origin
                 blockShape = new CANNON.Box(new CANNON.Vec3(width / 2, height / 2, depth / 2));
@@ -9996,8 +9996,8 @@
                             ghostBlockMesh.geometry = new THREE.BoxGeometry(1.2, 0.6, 2.2);
                         } else if (currentBlockType === doorItemName) {
                             ghostBlockMesh.geometry = new THREE.BoxGeometry(0, 0, 0);
-                            const doorMesh = new THREE.Mesh(new THREE.BoxGeometry(1.0, 2.0, 0.1), ghostBlockMaterial);
-                            doorMesh.position.set(0.5, 0, 0); // Offset para a dobradiça
+                            const doorMesh = new THREE.Mesh(new THREE.BoxGeometry(1.2, 2.4, 0.1), ghostBlockMaterial);
+                            doorMesh.position.set(0.6, 0, 0); // Offset para a dobradiça (1.2 / 2)
                             ghostBlockMesh.add(doorMesh);
                         } else if (currentBlockType === pestleItemName) {
                             ghostBlockMesh.geometry = new THREE.BoxGeometry(0, 0, 0);
@@ -10049,6 +10049,7 @@
                     else if (currentBlockType === campfireItemName) currentGhostHeight = 0.5;
                     else if (currentBlockType === torchItemName) currentGhostHeight = 0.8;
                     else if (currentBlockType === pestleItemName) currentGhostHeight = 0.5;
+                    else if (currentBlockType === doorItemName) currentGhostHeight = 2.4;
                     // Update ghost block geometry
                     // ghostBlockMesh.geometry = new THREE.BoxGeometry(currentGhostWidth, currentGhostHeight, currentGhostDepth); // Removido para lidar individualmente
 
@@ -10119,7 +10120,7 @@
                                 // NOVO: Alinha a posição Y na grade, considerando a altura da superfície da ilha como a base.
                                 // Isso garante que os blocos se encaixem verticalmente.
                                 // CORREÇÃO: As sementes não devem se encaixar na grade vertical, elas devem ser colocadas no chão.
-                                if (currentBlockType === 'muda_arvore' || currentBlockType === appleSeedItemName || currentBlockType === pineSeedItemName || currentBlockType === coconutItemName || currentBlockType === dirtItemName || currentBlockType === sandItemName || currentBlockType === raftItemName || currentBlockType === torchItemName || currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName || currentBlockType === furnaceItemName || currentBlockType === pestleItemName) {
+                                if (currentBlockType === 'muda_arvore' || currentBlockType === appleSeedItemName || currentBlockType === pineSeedItemName || currentBlockType === coconutItemName || currentBlockType === dirtItemName || currentBlockType === sandItemName || currentBlockType === raftItemName || currentBlockType === torchItemName || currentBlockType === workbenchItemName || currentBlockType === mesaItemName || currentBlockType === bigornaItemName || currentBlockType === furnaceItemName || currentBlockType === pestleItemName || currentBlockType === doorItemName) {
                                     placementPosition.y = basePosition.y;
                                 } else if (currentBlockType === boxItemName) {
                                     placementPosition.y = basePosition.y;
@@ -11174,6 +11175,7 @@
             window.beltItems = beltItems;
             window.updateUI = updateUI;
             window.coconutTrees = coconutTrees;
+            window.doorItemName = doorItemName;
             Object.defineProperty(window, 'selectedSlotIndex', {
                 get: () => selectedSlotIndex,
                 set: (v) => { selectedSlotIndex = v; }


### PR DESCRIPTION
- Added 'Porta' (Door) item with 1.2m x 2.4m dimensions.
- Implemented hinge-based rotation for the 3D model and physics body.
- Added 'T' key rotation support and Left Click toggle to open/close.
- Enabled ground placement for doors (ignoring vertical grid snapping).
- Added workbench recipe (4 wooden blocks) and starting items.