### PR TITLE
Add Glass item and update Window recipe

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1593,6 +1593,7 @@
         const bedItemName = 'cama';
         const doorItemName = 'porta';
         const windowItemName = 'janela';
+        const glassItemName = 'vidro';
 
         // NOVO: Variáveis para o sistema de destruição de blocos (Machado e Martelo)
         const axeItemName = 'machado'; // Nome do item de machado no inventário
@@ -1655,6 +1656,7 @@
                 { result: { name: sleepingMatItemName, quantity: 1 }, ingredients: [{ name: fabricItemName, quantity: 10 }, { name: capimItemName, quantity: 50 }, { name: ropeItemName, quantity: 2 }] }
             ],
             furnace: [
+                { result: { name: glassItemName, quantity: 10 }, ingredients: [{ name: sandItemName, quantity: 1 }] },
                 { result: { name: 'pote_barro', quantity: 20 }, ingredients: [{ name: 'terra', quantity: 1 }, { name: 'areia', quantity: 1 }] },
                 { result: { name: 'barra_ferro', quantity: 1 }, ingredients: [{ name: 'minerio_ferro', quantity: 1 }] },
                 { result: { name: 'bigorna', quantity: 1 }, ingredients: [{ name: 'minerio_ferro', quantity: 10 }] },
@@ -1680,7 +1682,7 @@
                 { result: { name: 'piso_pedra', quantity: 5 }, ingredients: [{ name: 'pedra', quantity: 1 }] },
                 { result: { name: bedItemName, quantity: 1 }, ingredients: [{ name: woodenBlockItemName, quantity: 10 }, { name: fabricItemName, quantity: 10 }, { name: capimItemName, quantity: 50 }, { name: ropeItemName, quantity: 2 }] },
                 { result: { name: doorItemName, quantity: 1 }, ingredients: [{ name: woodenBlockItemName, quantity: 4 }] },
-                { result: { name: windowItemName, quantity: 1 }, ingredients: [{ name: woodenBlockItemName, quantity: 2 }] }
+                { result: { name: windowItemName, quantity: 1 }, ingredients: [{ name: woodenBlockItemName, quantity: 2 }, { name: glassItemName, quantity: 1 }] }
             ]
         };
 
@@ -1716,6 +1718,7 @@
             [ironBarItemName]: 'Barra de Ferro',
             [dirtItemName]: 'Terra',
             [sandItemName]: 'Areia',
+            [glassItemName]: 'Vidro',
             [shovelItemName]: 'Pá de Pedra\nEspecialidade: Terra',
             [pickaxeItemName]: 'Picareta de Pedra\nEspecialidade: Pedra',
             [cobItemName]: 'Bloco de Barro',
@@ -1768,6 +1771,7 @@
             [ironBarItemName]: 2.0,
             [dirtItemName]: 0.2,
             [sandItemName]: 0.2,
+            [glassItemName]: 0.1,
             [shovelItemName]: 2.0,
             [pickaxeItemName]: 2.0,
             [cobItemName]: 2.0,
@@ -2554,6 +2558,7 @@
             if (itemName === coconutItemName) return "https://placehold.co/100x100/F5F5DC/FFFFFF?text=Coco";
             if (itemName === ropeItemName) return "https://placehold.co/100x100/8B4513/FFFFFF?text=Corda";
             if (itemName === windowItemName) return "https://placehold.co/100x100/87CEEB/FFFFFF?text=Janela";
+            if (itemName === glassItemName) return "https://placehold.co/100x100/E0FFFF/FFFFFF?text=Vidro";
             if (itemName === fabricItemName) return "https://placehold.co/100x100/FFFFFF/000000?text=Tecido";
             if (itemName === campfireItemName) return "https://placehold.co/100x100/FF4500/FFFFFF?text=Fogueira";
             if (itemName === torchItemName) return "https://placehold.co/100x100/FFA500/FFFFFF?text=Tocha";


### PR DESCRIPTION
Introduced Glass (Vidro) as a new item smelted from Sand in the furnace (1 Sand -> 10 Glass). Updated the Window crafting recipe to require 1 Glass and 2 Wooden Blocks. Also added item weight, display name, and placeholder icon for Glass.

---
*PR created automatically by Jules for task [14905863198682706808](https://jules.google.com/task/14905863198682706808) started by @Armandodecampos*