### PR TITLE
Fix Wood Object Dimensions and Texture Visibility

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -3753,7 +3753,7 @@
 
         function createCutTrunk(position, velocity) {
             const radius = 0.2;
-            const height = 0.5;
+            const height = 1.0;
             const mass = 10;
 
             // Approximation for semi-cylinder physics
@@ -3815,7 +3815,7 @@
 
         function createFirewood(position, velocity) {
             const radius = 0.15;
-            const height = 0.4;
+            const height = 1.0;
             const mass = 3;
 
             // Approximation for quarter-cylinder physics
@@ -6486,7 +6486,7 @@
             sailMaterialMesh = new THREE.MeshStandardMaterial({ color: 0xF5F5DC, side: THREE.DoubleSide });
             cobMaterialMesh = new THREE.MeshStandardMaterial({ color: 0x8B4513 });
             floorMaterialMesh = new THREE.MeshStandardMaterial({ color: 0xaaaaaa });
-            woodenPlankMaterialMesh = new THREE.MeshStandardMaterial({ color: 0xdeb887 });
+            woodenPlankMaterialMesh = new THREE.MeshStandardMaterial({ color: 0xdeb887, side: THREE.DoubleSide });
             stoneBlockMaterialMesh = new THREE.MeshStandardMaterial({ color: 0x888888 });
             woodenBlockMaterialMesh = new THREE.MeshStandardMaterial({ color: 0x8B4513 });
             stoneFloorMaterialMesh = new THREE.MeshStandardMaterial({ color: 0x888888 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
-      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -41,13 +41,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
Fixed an issue where "lenha" (firewood) and "tronco cortado" (cut log) objects had inverted textures, making them invisible from the outside. Also standardized their height to 1.0 units to match the "Tronco de árvore" (tree trunk) object. Physics colliders were updated accordingly to ensure consistency between the visual mesh and the physical simulation.

---
*PR created automatically by Jules for task [17419505149099396919](https://jules.google.com/task/17419505149099396919) started by @Armandodecampos*